### PR TITLE
Add support for nulls (Unit) in bind

### DIFF
--- a/src/test/scala/io/flow/postgresql/BulkDeleteSpec.scala
+++ b/src/test/scala/io/flow/postgresql/BulkDeleteSpec.scala
@@ -4,43 +4,43 @@ import org.scalatest.{FunSpec, Matchers}
 
 class BulkDeleteSpec extends FunSpec with Matchers {
 
-  def deleteFunction(item: String): String = {
-    println(s"Element [$item] deleted")
-    item
-  }
-
   it("empty list") {
     val emptyList = Seq()
 
     BulkDelete.byPage {
       emptyList
     } { e =>
-      deleteFunction(e)
+      sys.error("Should not have iterator")
     }
   }
 
   it("list with single element") {
-    var listWithOneElement = Seq("x")
-    BulkDelete.byPage {
-      listWithOneElement
-    } { e =>
-      val d = deleteFunction(e)
+    val original = Seq("x")
+    var items = original
+    var found = scala.collection.mutable.ListBuffer[String]()
 
-      if(d == "x")
-        listWithOneElement = Seq()
+    BulkDelete.byPage {
+      items
+    } { e =>
+      found += e
+      items = items.filter(_ != e)
     }
+    found should equal(original)
   }
 
   it("list with multiple elements") {
-    var listWithMultiElement = Seq("a", "b", "c")
-    BulkDelete.byPage {
-      listWithMultiElement
-    } { e =>
-      val d = deleteFunction(e)
+    val original = Seq(1, 2, 3)
+    var items = original
+    var found = scala.collection.mutable.ListBuffer[Int]()
 
-      if(d == "c")
-        listWithMultiElement = Seq()
+    BulkDelete.byPage {
+      println("ADSFASDF")
+      items
+    } { e =>
+      found += e
+      items = items.filter(_ != e)
     }
+    found should equal(original)
   }
 
 }

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -176,6 +176,14 @@ class QuerySpec extends FunSpec with Matchers {
     )
   }
 
+  it("unit") {
+    validate(
+      Query("insert into users (first) values ({first})").bind("first", None),
+      "insert into users (first) values ({first})",
+      "insert into users (first) values (null)"
+    )
+  }
+
   it("text") {
     validate(
       Query("select * from users").optionalText("users.email", None),


### PR DESCRIPTION
  - This is required to use the query library to implement
    insert or update when you might call bind("foo", None). We
    need that to replace {foo} with null otherwise
    we end up parsing a sql query with a '{foo}' in it

  - Has added benefit of keeping bind variable names unique
    even if a specific code path doesn't actually bind a variable name