### PR TITLE
Add append to order by

### DIFF
--- a/src/main/scala/io/flow/postgresql/OrderBy.scala
+++ b/src/main/scala/io/flow/postgresql/OrderBy.scala
@@ -7,6 +7,14 @@ case class OrderBy(clauses: Seq[String]) {
     case multiple => Some(multiple.mkString(", "))
   }
 
+  /**
+    * Creates a new OrderBy with this clause appended
+    */
+  def append(clause: String): OrderBy = {
+    OrderBy(
+      clauses = clauses ++ Seq(clause)
+    )
+  }
 }
 
 object OrderBy {

--- a/src/test/scala/io/flow/postgresql/OrderBySpec.scala
+++ b/src/test/scala/io/flow/postgresql/OrderBySpec.scala
@@ -80,4 +80,10 @@ class OrderBySpec extends FunSpec with Matchers {
     ))
   }
 
+  it("append") {
+    val a = OrderBy("-lower(projects.key)")
+    val combined = a.append("-created_at")
+    combined.sql should be(Some("lower(projects.key) desc, -created_at"))
+  }
+
 }


### PR DESCRIPTION
- Will enable use case in billing to always append a final sort to
    the order by clause, regardless of whether we are using the default
    order by or one passed in from client.