### PR TITLE
Make uniqueBindName public

### DIFF
--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -512,7 +512,7 @@ case class Query(
     * @param name Preferred name of bind variable - will be used if unique,
     *             otherwise we generate a unique version.
     */
-  private[this] def uniqueBindName(name: String): String = {
+  def uniqueBindName(name: String): String = {
     val safeName = BindVariable.safeName(name)
 
     bind.find(_.name == safeName) match {


### PR DESCRIPTION
- need this in search to handle org query parsing where certain variables
    may be defined multiple times