### PR TITLE
Last id pager

### DIFF
--- a/src/main/scala/io/flow/postgresql/Pager.scala
+++ b/src/main/scala/io/flow/postgresql/Pager.scala
@@ -70,6 +70,7 @@ trait GenericPager[T, Context] extends Iterator[T] {
   private[this] var currentPageIterator: Iterator[T] = Iterator.empty
   private[this] var currentContext: Context = initialContext
 
+  // load the first page
   loadPage()
 
   /**

--- a/src/main/scala/io/flow/postgresql/Pager.scala
+++ b/src/main/scala/io/flow/postgresql/Pager.scala
@@ -88,19 +88,19 @@ trait GenericPager[T, Context] extends Iterator[T] {
   /**
     * Produces the next page of elements
     * @param context the context keeping track of the traversal the elements
-    * @return the
+    * @return the next page of elements
     */
   def page(context: Context): Iterable[T]
 
   /**
     * Tests whether this iterator can provide another element.
-    * @return  `true` if a subsequent call to `next` will yield an element, `false` otherwise.
+    * @return `true` if a subsequent call to `next` will yield an element, `false` otherwise.
     */
   def hasNext: Boolean = currentPageIterator.hasNext
 
   /**
     * Produces the next element of this iterator.
-    * @return  the next element of this iterator, if `hasNext` is `true`, throws a [[NoSuchElementException]] otherwise.
+    * @return the next element of this iterator, if `hasNext` is `true`, throws a [[NoSuchElementException]] otherwise.
     */
   def next: T = {
     if (hasNext) nextAndReload()

--- a/src/main/scala/io/flow/postgresql/Pager.scala
+++ b/src/main/scala/io/flow/postgresql/Pager.scala
@@ -2,73 +2,89 @@ package io.flow.postgresql
 
 object Pager {
 
-  /**
-    * Helper to create a pager, inferring the types from the function
-    * returning each page of results.
-    * 
-    * Example:
-    * 
-    *    Pager.create { offset =>
-    *      SubscriptionsDao.findAll(
-    *        publication = Some(Publication.DailySummary),
-    *        offset = offset
-    *      )
-    *    }.foreach { subscription =>
-    *      println("subscription: " + subscription)
-    *    }
-    */
-  def create[T](
-    f: Long => Iterable[T]
-  ): Pager[T] = {
-    new Pager[T] {
-      override def page(offset: Long): Iterable[T] = f(offset)
+  def create[T](pagingFunction: Long => Iterable[T]): Pager[T] = byOffset[T](pagingFunction)
+
+  def byOffset[T](pagingFunction: Long => Iterable[T]): Pager[T] = new Pager[T] {
+    override def page(offset: Long): Iterable[T] = pagingFunction(offset)
+  }
+
+  def byLastId[T, Id](pagingFunction: Option[Id] => Iterable[T], getId: T => Id): LastIdPager[T, Id] = {
+    new LastIdPager[T, Id] {
+      override def page(lastId: Option[Id]): Iterable[T] = pagingFunction(lastId)
+      override def extractId(element: T): Id = getId(element)
     }
   }
 
 }
 
-/**
-  * Trait that enables us to iterate over a large number of results
-  * (e.g. from a database query) one page at a time.
-  */
-trait Pager[T] extends Iterator[T] {
+trait Pager[T] extends OffsetPager[T]
 
-  private[this] var nextResult: Option[T] = None
-  private[this] var currentPage: Seq[T] = Nil
-  private[this] var currentOffset: Int = 0
-  private[this] var currentIndex: Int = 0
+trait GenericPager[T, Context] extends Iterator[T] {
 
-  prepareNextResult()
+  private[this] var currentPageIterator: Iterator[T] = Iterator.empty
+  private[this] var currentContext: Context = initialContext
+
+  loadPage()
 
   /**
-    * Returns the next page of results starting at the specified
-    * offset
+    * Returns the initial context
     */
-  def page(offset: Long): Iterable[T]
+  def initialContext: Context
 
-  def hasNext: Boolean = !nextResult.isEmpty
+  /**
+    * Updates the context keeping track of the traversal of the elements based on the next element produced.
+    * This function is called every time the iterator produces the next element.
+    * @param element the next element produced
+    */
+  def updateContext(currentContext: Context, element: T): Context
 
+  /**
+    * Produces the next page of elements
+    * @param context the context keeping track of the traversal the elements
+    * @return the
+    */
+  def page(context: Context): Iterable[T]
+
+  /**
+    * Tests whether this iterator can provide another element.
+    * @return  `true` if a subsequent call to `next` will yield an element, `false` otherwise.
+    */
+  def hasNext: Boolean = currentPageIterator.hasNext
+
+  /**
+    * Produces the next element of this iterator.
+    * @return  the next element of this iterator, if `hasNext` is `true`, throws a [[NoSuchElementException]] otherwise.
+    */
   def next: T = {
-    val result = nextResult.getOrElse {
-      throw new NoSuchElementException()
-    }
-    prepareNextResult()
-    result
+    if (hasNext) nextAndReload()
+    else throw new NoSuchElementException()
   }
 
-  private[this] def prepareNextResult() {
-    currentPage.lift(currentIndex) match {
-      case Some(result) => {
-        this.nextResult = Some(result)
-        currentIndex += 1
-      }
-      case None => {
-        currentPage = page(currentOffset).toSeq
-        currentOffset += currentPage.size
-        this.nextResult = currentPage.headOption
-        currentIndex = 1
-      }
-    }
+  private def nextAndReload(): T = {
+    val next = currentPageIterator.next
+    currentContext = updateContext(currentContext, next)
+    // end of the current page: load the next one
+    if (!currentPageIterator.hasNext) loadPage()
+    next
   }
+
+  private def loadPage(): Unit = currentPageIterator = page(currentContext).iterator
+
+}
+
+trait OffsetPager[T] extends GenericPager[T, Long] {
+  override def initialContext: Long = 0L
+  override def updateContext(offset: Long, nextElement: T): Long = offset + 1
+}
+
+trait LastIdPager[T, Id] extends GenericPager[T, Option[Id]] {
+  override def initialContext: Option[Id] = None
+  override def updateContext(context: Option[Id], nextElement: T): Option[Id] = Some(extractId(nextElement))
+
+  /**
+    * Extracts the id of the element.
+    * This function is called when the next element is produced to extract its id
+    */
+  def extractId(element: T): Id
 
 }

--- a/src/test/scala/io/flow/postgresql/LastIdPagerSpec.scala
+++ b/src/test/scala/io/flow/postgresql/LastIdPagerSpec.scala
@@ -1,0 +1,51 @@
+package io.flow.postgresql
+
+import org.scalatest.{FunSpec, Matchers}
+
+class LastIdPagerSpec extends FunSpec with Matchers {
+
+  it("empty list") {
+    val pager = Pager.byLastId[Long, Long](lastId => Nil, identity)
+    pager.hasNext should be(false)
+
+    intercept[NoSuchElementException] {
+      pager.next()
+    }
+  }
+
+  it("single page list") {
+    val pager = Pager.byLastId[String, Long](
+      {
+        case None => Seq("*", "**")
+        case Some(2L) => Nil
+      },
+      _.size
+    )
+
+    pager.hasNext should be(true)
+    pager.next should be("*")
+    pager.hasNext should be(true)
+    pager.next should be("**")
+    pager.hasNext should be(false)
+  }
+
+  it("multiple pages") {
+    val pager = Pager.byLastId[String, Long](
+      {
+        case None => Seq("*", "**")
+        case Some(2L) => Seq("****")
+        case Some(4L) => Nil
+      },
+      _.size
+    )
+
+    pager.hasNext should be(true)
+    pager.next should be("*")
+    pager.hasNext should be(true)
+    pager.next should be("**")
+    pager.hasNext should be(true)
+    pager.next should be("****")
+    pager.hasNext should be(false)
+  }
+
+}


### PR DESCRIPTION
Add a pager based on the last seen id.

The idea is to move away from regular offset for scanning huge tables (several hundreds of thousands of lines) and rely on the index to query the elements that are greater (or lesser) than the last id.

An actual use case is repricing all the subcatalog items (after a change of rate for example)


 

