### PR TITLE
Move bind variable logic to own wrapper class BindVariables

### DIFF
--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -5,11 +5,11 @@ import java.util.UUID
 import anorm.NamedParameter
 import org.joda.time.{DateTime, LocalDate}
 
-sealed trait BindVariable {
+sealed trait BindVariable[T] {
 
   def name: String
   def defaultValueFunctions: Seq[Query.Function] = Nil
-  def value: Any
+  def value: T
   def toNamedParameter: NamedParameter
   def psqlType: Option[String]
 
@@ -21,45 +21,45 @@ sealed trait BindVariable {
 
 object BindVariable {
 
-  case class Int(override val name: String, override val value: Number) extends BindVariable {
+  case class Int(override val name: String, override val value: _root_.scala.Int) extends BindVariable[_root_.scala.Int] {
     override val psqlType: Option[String] = Some("int")
     override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
   }
 
-  case class BigInt(override val name: String, override val value: Number) extends BindVariable {
+  case class BigInt(override val name: String, override val value: Long) extends BindVariable[Long] {
     override val psqlType: Option[String] = Some("bigint")
     override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
   }
 
-  case class Num(override val name: String, override val value: Number) extends BindVariable {
+  case class Num(override val name: String, override val value: Number) extends BindVariable[Number] {
     override val psqlType: Option[String] = Some("numeric")
     override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
   }
 
-  case class Str(override val name: String, override val value: String) extends BindVariable {
+  case class Str(override val name: String, override val value: String) extends BindVariable[String] {
     override val psqlType: Option[String] = None
     override val defaultValueFunctions: Seq[Query.Function] = Seq(Query.Function.Trim)
     override def toNamedParameter: NamedParameter = NamedParameter(name, value)
   }
 
-  case class Uuid(override val name: String, override val value: UUID) extends BindVariable {
+  case class Uuid(override val name: String, override val value: UUID) extends BindVariable[UUID] {
     override val psqlType: Option[String] = Some("uuid")
     override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
   }
 
-  case class DateVar(override val name: String, override val value: LocalDate) extends BindVariable {
+  case class DateVar(override val name: String, override val value: LocalDate) extends BindVariable[LocalDate] {
     override val psqlType: Option[String] = Some("date")
     override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
   }
 
-  case class DateTimeVar(override val name: String, override val value: DateTime) extends BindVariable {
+  case class DateTimeVar(override val name: String, override val value: DateTime) extends BindVariable[DateTime] {
     override val psqlType: Option[String] = Some("timestamptz")
     override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
   }
 
-  case class Unit(override val name: String) extends BindVariable {
+  case class Unit(override val name: String) extends BindVariable[_root_.scala.Unit] {
     override val psqlType: Option[String] = None
-    override val value: Any = None
+    override val value: _root_.scala.Unit = ()
     override def toNamedParameter: NamedParameter = NamedParameter(name, Option.empty[String])
   }
 

--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -15,7 +15,7 @@ case class BindVariables() {
 
   private[this] val internalVariables = scala.collection.mutable.ListBuffer[BindVariable[_]]()
 
-  def variables(): Seq[BindVariable[_]] = internalVariables.toSeq
+  def variables(): Seq[BindVariable[_]] = internalVariables
 
   /**
     * Generates a unique bind variable name from the specified input

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -423,12 +423,9 @@ case class Query(
    * variables interpolated for easy inspection.
    */
   def interpolate(): String = {
-    println(s"INTERPOLATE: ${bindVariables.variables.size}")
     bindVariables.variables.foldLeft(sql()) { case (query, bindVar) =>
-      println(s"Bindvar class[${bindVar.getClass().getName}]: $bindVar")
       bindVar match {
         case BindVariable.Int(name, value) => {
-          println(s"name[$name] value[$value]")
           query.
             replace(bindVar.sql, value.toString).
             replace(s"{$name}", value.toString)

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -32,7 +32,7 @@ object Query {
 case class Query(
   base: String,
   conditions: Seq[String] = Nil,
-  bind: Seq[BindVariable] = Nil,
+  bind: Seq[BindVariable[_]] = Nil,
   orderBy: Seq[String] = Nil,
   limit: Option[Long] = None,
   offset: Option[Long] = None,
@@ -502,7 +502,7 @@ case class Query(
   /**
     * Generates a unique, as friendly as possible, bind variable name
     */
-  private[this] def toBindVariable(name: String, value: Any): BindVariable = {
+  private[this] def toBindVariable(name: String, value: Any): BindVariable[_] = {
     value match {
       case v: UUID => BindVariable.Uuid(name, v)
       case v: LocalDate => BindVariable.DateVar(name, v)

--- a/src/test/scala/io/flow/postgresql/BulkDeleteSpec.scala
+++ b/src/test/scala/io/flow/postgresql/BulkDeleteSpec.scala
@@ -34,7 +34,6 @@ class BulkDeleteSpec extends FunSpec with Matchers {
     var found = scala.collection.mutable.ListBuffer[Int]()
 
     BulkDelete.byPage {
-      println("ADSFASDF")
       items
     } { e =>
       found += e

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -502,7 +502,7 @@ class QuerySpec extends FunSpec with Matchers {
     } match {
       case Success(_) => fail("Expected error for duplicate bind variable")
       case Failure(ex) => {
-        ex.getMessage should be("Bind variable named 'email' already defined")
+        ex.getMessage should be("assertion failed: Bind variable named 'email' already defined")
       }
     }
   }

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -671,4 +671,15 @@ class QuerySpec extends FunSpec with Matchers {
     )
   }
 
+  it("queries that share bind variables (note status2 in bind key)") {
+    val a = Query("select * from users").equals("status", "live")
+    val b = Query("select id from users", bindVariables = a.bindVariables).equals("status", "draft")
+
+    validate(
+      a.and(s"id in (${b.sql()})"),
+      "select * from users where status = trim({status}) and id in (select id from users where status = trim({status2}))",
+      "select * from users where status = trim('live') and id in (select id from users where status = trim('draft'))"
+    )
+  }
+
 }


### PR DESCRIPTION
 - Use case is around supporting natural lang queries executed as SQL Queries
  - Need to share the namespace for bind variables - and the idea is to
    construct multiple queries sharing a bind variable container.
 - most of the pr moves bits around. the key change is this line to allow multiple sql query objects to share bind variables: https://github.com/flowcommerce/lib-postgresql/pull/79/files#diff-f2f031573f3d51924b11ba007120a241R41
 - end goal is to remove the call to `interpolate` here: https://github.com/flowcommerce/experience/pull/1434/files#diff-bb3d57c1fca39c74835f22d23db6eb8eR87
 - this is in the context of experiments v1.1 where we are adding keyword search and status filter - we want to implement using query builders for UI and backend - so frontend exposes ability to build a query - backend takes `canada and status:live` and returns matching experiences
 - Does break the contract (bind => bindVariables) => but I don't think we ever accessed directly thus should be transparent to rollout