### PR TITLE
Refactor query bind variables to bind names late

### DIFF
--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -26,6 +26,9 @@ object BindVariable {
     */
   def apply(name: String, value: Any): BindVariable[_] = {
     value match {
+      case Some(v) => apply(name, v)
+      case _: Unit | None => BindVariable.Unit(name)
+
       case v: UUID => BindVariable.Uuid(name, v)
       case v: LocalDate => BindVariable.DateVar(name, v)
       case v: DateTime => BindVariable.DateTimeVar(name, v)
@@ -33,7 +36,6 @@ object BindVariable {
       case v: Long => BindVariable.BigInt(name, v)
       case v: Number => BindVariable.Num(name, v)
       case v: String => BindVariable.Str(name, v)
-      case _: Unit => BindVariable.Unit(name)
       case _ => BindVariable.Str(name, value.toString)
     }
   }
@@ -101,9 +103,9 @@ object BindVariable {
     override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
   }
 
-  case class Unit(override val name: String) extends BindVariable[_root_.scala.Unit] {
+  case class Unit(override val name: String) extends BindVariable[Option[_]] {
     override val psqlType: Option[String] = None
-    override val value: _root_.scala.Unit = ()
+    override val value: Option[_] = None
     override def toNamedParameter: NamedParameter = NamedParameter(name, Option.empty[String])
   }
 

--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -5,11 +5,70 @@ import java.util.UUID
 import anorm.NamedParameter
 import org.joda.time.{DateTime, LocalDate}
 
-sealed trait BindVariable {
+import scala.annotation.tailrec
+
+/**
+  * A container of bind variables used to generate unique,
+  * readable names for each bind variables.
+  */
+case class BindVariables() {
+
+  private[this] val internalVariables = scala.collection.mutable.ListBuffer[BindVariable[_]]()
+
+  def variables(): Seq[BindVariable[_]] = internalVariables
+
+  /**
+    * Generates a unique bind variable name from the specified input
+    *
+    * @param name Preferred name of bind variable - will be used if unique,
+    *             otherwise we generate a unique version.
+    */
+  def uniqueName(name: String): String = {
+    uniqueName(name, 1)
+  }
+
+  @tailrec
+  private[this] def uniqueName(original: String, count: Int): String = {
+    assert(count >= 1)
+    val scrubbedName = BindVariable.safeName(
+      if (count == 1) { original } else { s"$original$count" }
+    )
+
+    if (internalVariables.exists(_.name == scrubbedName)) {
+      uniqueName(original, count + 1)
+    } else {
+      scrubbedName
+    }
+  }
+
+  def addWithUniqueName(name: String, value: Any): BindVariable[_] = {
+    add(uniqueName(name), value)
+  }
+
+  /**
+    * Creates a typed instances of a BindVariable for all types
+    */
+  def add(name: String, value: Any): BindVariable[_] = {
+    val variable = value match {
+      case v: UUID => BindVariable.Uuid(name, v)
+      case v: LocalDate => BindVariable.DateVar(name, v)
+      case v: DateTime => BindVariable.DateTimeVar(name, v)
+      case v: Int => BindVariable.Int(name, v)
+      case v: Long => BindVariable.BigInt(name, v)
+      case v: Number => BindVariable.Num(name, v)
+      case v: String => BindVariable.Str(name, v)
+      case _: Unit => BindVariable.Unit(name)
+      case _ => BindVariable.Str(name, value.toString)
+    }
+    internalVariables.append(variable)
+    variable
+  }
+}
+sealed trait BindVariable[T] extends Product with Serializable {
 
   def name: String
   def defaultValueFunctions: Seq[Query.Function] = Nil
-  def value: Any
+  def value: T
   def toNamedParameter: NamedParameter
   def psqlType: Option[String]
 
@@ -21,52 +80,11 @@ sealed trait BindVariable {
 
 object BindVariable {
 
-  case class Int(override val name: String, override val value: Number) extends BindVariable {
-    override val psqlType: Option[String] = Some("int")
-    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
-  }
-
-  case class BigInt(override val name: String, override val value: Number) extends BindVariable {
-    override val psqlType: Option[String] = Some("bigint")
-    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
-  }
-
-  case class Num(override val name: String, override val value: Number) extends BindVariable {
-    override val psqlType: Option[String] = Some("numeric")
-    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
-  }
-
-  case class Str(override val name: String, override val value: String) extends BindVariable {
-    override val psqlType: Option[String] = None
-    override val defaultValueFunctions: Seq[Query.Function] = Seq(Query.Function.Trim)
-    override def toNamedParameter: NamedParameter = NamedParameter(name, value)
-  }
-
-  case class Uuid(override val name: String, override val value: UUID) extends BindVariable {
-    override val psqlType: Option[String] = Some("uuid")
-    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
-  }
-
-  case class DateVar(override val name: String, override val value: LocalDate) extends BindVariable {
-    override val psqlType: Option[String] = Some("date")
-    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
-  }
-
-  case class DateTimeVar(override val name: String, override val value: DateTime) extends BindVariable {
-    override val psqlType: Option[String] = Some("timestamptz")
-    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
-  }
-
-  case class Unit(override val name: String) extends BindVariable {
-    override val psqlType: Option[String] = None
-    override val value: Any = None
-    override def toNamedParameter: NamedParameter = NamedParameter(name, Option.empty[String])
-  }
-
   private[this] val LeadingUnderscores = """^_+""".r
   private[this] val MultiUnderscores = """__+""".r
   private[this] val TrailingUnderscores = """_+$""".r
   private[this] val ScrubName = """[^\w\d\_]""".r
+  private[this] val DefaultBindName = "bind"
 
   def safeName(name: String): String = {
     val idx = name.lastIndexOf(".")
@@ -82,10 +100,53 @@ object BindVariable {
       ""
     )
 
-    safeName match {
-      case "" => "bind"
-      case _ => safeName
+    if (safeName.isEmpty) {
+      DefaultBindName
+    } else {
+      safeName
     }
+  }
+
+  case class Int(override val name: String, override val value: _root_.scala.Int) extends BindVariable[_root_.scala.Int] {
+    override val psqlType: Option[String] = Some("int")
+    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
+  }
+
+  case class BigInt(override val name: String, override val value: Long) extends BindVariable[Long] {
+    override val psqlType: Option[String] = Some("bigint")
+    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
+  }
+
+  case class Num(override val name: String, override val value: Number) extends BindVariable[Number] {
+    override val psqlType: Option[String] = Some("numeric")
+    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
+  }
+
+  case class Str(override val name: String, override val value: String) extends BindVariable[String] {
+    override val psqlType: Option[String] = None
+    override val defaultValueFunctions: Seq[Query.Function] = Seq(Query.Function.Trim)
+    override def toNamedParameter: NamedParameter = NamedParameter(name, value)
+  }
+
+  case class Uuid(override val name: String, override val value: UUID) extends BindVariable[UUID] {
+    override val psqlType: Option[String] = Some("uuid")
+    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
+  }
+
+  case class DateVar(override val name: String, override val value: LocalDate) extends BindVariable[LocalDate] {
+    override val psqlType: Option[String] = Some("date")
+    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
+  }
+
+  case class DateTimeVar(override val name: String, override val value: DateTime) extends BindVariable[DateTime] {
+    override val psqlType: Option[String] = Some("timestamptz")
+    override def toNamedParameter: NamedParameter = NamedParameter(name, value.toString)
+  }
+
+  case class Unit(override val name: String) extends BindVariable[_root_.scala.Unit] {
+    override val psqlType: Option[String] = None
+    override val value: _root_.scala.Unit = ()
+    override def toNamedParameter: NamedParameter = NamedParameter(name, Option.empty[String])
   }
 
 }

--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -5,60 +5,6 @@ import java.util.UUID
 import anorm.NamedParameter
 import org.joda.time.{DateTime, LocalDate}
 
-import scala.annotation.tailrec
-
-/**
-  * A container of bind variables used to generate unique,
-  * readable names for each bind variables.
-  */
-object BindVariables {
-
-  /**
-    * Generates a unique bind variable name from the specified input
-    *
-    * @param name Preferred name of bind variable - will be used if unique,
-    *             otherwise we generate a unique version.
-    */
-  def uniqueName(existing: Seq[BindVariable[_]], name: String): String = {
-    uniqueName(existing, name, 1)
-  }
-
-  @tailrec
-  private[this] def uniqueName(existing: Seq[BindVariable[_]], original: String, count: Int): String = {
-    assert(count >= 1)
-    val scrubbedName = BindVariable.safeName(
-      if (count == 1) { original } else { s"$original$count" }
-    )
-
-    if (existing.exists(_.name == scrubbedName)) {
-      uniqueName(existing, original, count + 1)
-    } else {
-      scrubbedName
-    }
-  }
-
-  def createWithUniqueName(existing: Seq[BindVariable[_]], name: String, value: Any): BindVariable[_] = {
-    create(uniqueName(existing, name), value)
-  }
-
-  /**
-    * Creates a typed instances of a BindVariable for all types
-    */
-  def create(name: String, value: Any): BindVariable[_] = {
-    value match {
-      case v: UUID => BindVariable.Uuid(name, v)
-      case v: LocalDate => BindVariable.DateVar(name, v)
-      case v: DateTime => BindVariable.DateTimeVar(name, v)
-      case v: Int => BindVariable.Int(name, v)
-      case v: Long => BindVariable.BigInt(name, v)
-      case v: Number => BindVariable.Num(name, v)
-      case v: String => BindVariable.Str(name, v)
-      case _: Unit => BindVariable.Unit(name)
-      case _ => BindVariable.Str(name, value.toString)
-    }
-  }
-}
-
 sealed trait BindVariable[T] extends Product with Serializable {
 
   def name: String
@@ -74,6 +20,23 @@ sealed trait BindVariable[T] extends Product with Serializable {
 }
 
 object BindVariable {
+
+  /**
+    * Creates a typed instances of a BindVariable for all types
+    */
+  def apply(name: String, value: Any): BindVariable[_] = {
+    value match {
+      case v: UUID => BindVariable.Uuid(name, v)
+      case v: LocalDate => BindVariable.DateVar(name, v)
+      case v: DateTime => BindVariable.DateTimeVar(name, v)
+      case v: _root_.scala.Int => BindVariable.Int(name, v)
+      case v: Long => BindVariable.BigInt(name, v)
+      case v: Number => BindVariable.Num(name, v)
+      case v: String => BindVariable.Str(name, v)
+      case _: Unit => BindVariable.Unit(name)
+      case _ => BindVariable.Str(name, value.toString)
+    }
+  }
 
   private[this] val LeadingUnderscores = """^_+""".r
   private[this] val MultiUnderscores = """__+""".r

--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -88,7 +88,6 @@ object BindVariable {
   case class Str(override val name: String, override val value: String) extends BindVariable[String] {
     override val defaultValueFunctions: Seq[Query.Function] = Seq(Query.Function.Trim)
     override def toNamedParameter: NamedParameter = NamedParameter(name, value)
-    println(s"STRING: $name value:$value")
   }
 
   case class Uuid(override val name: String, override val value: UUID) extends BindVariable[UUID] {

--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -11,11 +11,9 @@ import scala.annotation.tailrec
   * A container of bind variables used to generate unique,
   * readable names for each bind variables.
   */
-case class BindVariables() {
+object BindVariables {
 
   private[this] val internalVariables = scala.collection.mutable.ListBuffer[BindVariable[_]]()
-
-  def variables(): Seq[BindVariable[_]] = internalVariables
 
   /**
     * Generates a unique bind variable name from the specified input
@@ -41,14 +39,14 @@ case class BindVariables() {
     }
   }
 
-  def addWithUniqueName(name: String, value: Any): BindVariable[_] = {
-    add(uniqueName(name), value)
+  def createWithUniqueName(name: String, value: Any): BindVariable[_] = {
+    create(uniqueName(name), value)
   }
 
   /**
     * Creates a typed instances of a BindVariable for all types
     */
-  def add(name: String, value: Any): BindVariable[_] = {
+  def create(name: String, value: Any): BindVariable[_] = {
     val variable = value match {
       case v: UUID => BindVariable.Uuid(name, v)
       case v: LocalDate => BindVariable.DateVar(name, v)
@@ -64,6 +62,7 @@ case class BindVariables() {
     variable
   }
 }
+
 sealed trait BindVariable[T] extends Product with Serializable {
 
   def name: String

--- a/src/main/scala/io/flow/postgresql/BindVariable.scala
+++ b/src/main/scala/io/flow/postgresql/BindVariable.scala
@@ -5,8 +5,6 @@ import java.util.UUID
 import anorm.NamedParameter
 import org.joda.time.{DateTime, LocalDate}
 
-import scala.runtime.BoxedUnit
-
 sealed trait BindVariable[T] extends Product with Serializable {
 
   def name: String
@@ -22,6 +20,8 @@ sealed trait BindVariable[T] extends Product with Serializable {
 }
 
 object BindVariable {
+
+  val DefaultBindName = "bind"
 
   /**
     * Creates a typed instances of a BindVariable for all types
@@ -48,7 +48,6 @@ object BindVariable {
   private[this] val MultiUnderscores = """__+""".r
   private[this] val TrailingUnderscores = """_+$""".r
   private[this] val ScrubName = """[^\w\d\_]""".r
-  private[this] val DefaultBindName = "bind"
 
   def safeName(name: String): String = {
     val idx = name.lastIndexOf(".")
@@ -108,7 +107,7 @@ object BindVariable {
   }
 
   case class Unit(override val name: String) extends BindVariable[scala.Unit] {
-    override def value = sys.error(s"Value not supported for unit type")
+    override def value: scala.Unit = sys.error(s"Value not supported for unit type")
     override def toNamedParameter: NamedParameter = NamedParameter(name, Option.empty[String])
   }
 

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -297,6 +297,13 @@ case class Query(
       !explicitBindVariables.exists(_.name == name),
       s"Bind variable named '$name' already defined"
     )
+    val safe = BindVariable.safeName(name)
+    assert(
+      safe == name,
+      s"Invalid bind variable name[$name]" + (
+        if (safe == BindVariable.DefaultBindName) { "" } else { s" suggest: $safe" }
+      )
+    )
     this.copy(
       explicitBindVariables = explicitBindVariables ++ Seq(
         BindVariable(name, value)

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -32,13 +32,13 @@ object Query {
 case class Query(
   base: String,
   conditions: Seq[String] = Nil,
-  bind: Seq[BindVariable] = Nil,
   orderBy: Seq[String] = Nil,
   limit: Option[Long] = None,
   offset: Option[Long] = None,
   debug: Boolean = false,
   groupBy: Seq[String] = Nil,
-  locking: Option[String] = None
+  locking: Option[String] = None,
+  bindVariables: BindVariables = BindVariables()
 ) {
 
   def equals[T](column: String, value: Option[T]): Query = optionalOperation(column, "=", value)
@@ -88,13 +88,12 @@ case class Query(
     columnFunctions: Seq[Query.Function] = Nil,
     valueFunctions: Seq[Query.Function] = Nil
   ): Query = {
-    val bindVar = toBindVariable(uniqueBindName(column), value)
+    val bindVar = bindVariables.addWithUniqueName(column, value)
     val exprColumn = withFunctions(column, columnFunctions, value)
     val exprValue = withFunctions(bindVar.sql, valueFunctions ++ bindVar.defaultValueFunctions, value)
 
     this.copy(
-      conditions = conditions ++ Seq(s"$exprColumn $operator $exprValue"),
-      bind = bind ++ Seq(bindVar)
+      conditions = conditions ++ Seq(s"$exprColumn $operator $exprValue")
     )
   }
 
@@ -172,21 +171,19 @@ case class Query(
         )
       }
       case multiple => {
-        val bindVariables = multiple.zipWithIndex.map { case (value, i) =>
-          val n = if (i == 0) { column } else { s"${column}${i+1}" }
-          toBindVariable(uniqueBindName(n), value)
+        val variables = multiple.map { value =>
+          bindVariables.addWithUniqueName(column, value)
         }
 
         val exprColumn = withFunctions(column, columnFunctions, multiple.head)
 
         val cond = s"$exprColumn $operation (%s)".format(
-          bindVariables.map { bindVar =>
+          variables.map { bindVar =>
             withFunctions(bindVar.sql, valueFunctions ++ bindVar.defaultValueFunctions, multiple.head)
           }.mkString(", ")
         )
         this.copy(
-          conditions = conditions ++ Seq(cond),
-          bind = bind ++ bindVariables
+          conditions = conditions ++ Seq(cond)
         )
       }
     }
@@ -246,14 +243,12 @@ case class Query(
     name: String,
     value: T
   ): Query = {
-    bind.find(_.name == name) match {
-      case None => {
-        this.copy(bind = bind ++ Seq(toBindVariable(name, value)))
-      }
-      case Some(_) => {
-        sys.error(s"Bind variable named '$name' already defined")
-      }
-    }
+    assert(
+      !bindVariables.variables.exists(_.name == name),
+      s"Bind variable named '$name' already defined"
+    )
+    bindVariables.add(name, value)
+    this
   }
 
   def bind[T](
@@ -296,8 +291,8 @@ case class Query(
     )
   }
 
-  def isTrue(column: String): Query = boolean(column, true)
-  def isFalse(column: String): Query = boolean(column, false)
+  def isTrue(column: String): Query = boolean(column, value = true)
+  def isFalse(column: String): Query = boolean(column, value = false)
 
   def boolean(column: String, value: Option[Boolean]): Query = {
     value match {
@@ -428,7 +423,7 @@ case class Query(
    * variables interpolated for easy inspection.
    */
   def interpolate(): String = {
-    bind.foldLeft(sql()) { case (query, bindVar) =>
+    bindVariables.variables.foldLeft(sql()) { case (query, bindVar) =>
       bindVar match {
         case BindVariable.Int(name, value) => {
           query.
@@ -476,12 +471,12 @@ case class Query(
     * Returns debugging information about this query
     */
   def debuggingInfo(): String = {
-    if (bind.isEmpty) {
+    if (bindVariables.variables.isEmpty) {
       interpolate()
     } else {
       Seq(
         sql(),
-        bind.map { bv => s" - ${bv.name}: ${bv.value}" }.mkString("\n"),
+        bindVariables.variables.map { bv => s" - ${bv.name}: ${bv.value}" }.mkString("\n"),
         "Interpolated:",
         interpolate()
       ).mkString("\n")
@@ -495,40 +490,7 @@ case class Query(
     if (debug) {
       println(debuggingInfo())
     }
-    SQL(sql()).on(bind.map(_.toNamedParameter): _*)
-  }
-
-
-  /**
-    * Generates a unique, as friendly as possible, bind variable name
-    */
-  private[this] def toBindVariable(name: String, value: Any): BindVariable = {
-    value match {
-      case v: UUID => BindVariable.Uuid(name, v)
-      case v: LocalDate => BindVariable.DateVar(name, v)
-      case v: DateTime => BindVariable.DateTimeVar(name, v)
-      case v: Int => BindVariable.Int(name, v)
-      case v: Long => BindVariable.BigInt(name, v)
-      case v: Number => BindVariable.Num(name, v)
-      case v: String => BindVariable.Str(name, v)
-      case _: Unit => BindVariable.Unit(name)
-      case _ => BindVariable.Str(name, value.toString)
-    }
-  }
-
-  /**
-    * Generates a unique bind variable name from the specified input
-    *
-    * @param name Preferred name of bind variable - will be used if unique,
-    *             otherwise we generate a unique version.
-    */
-  def uniqueBindName(name: String): String = {
-    val safeName = BindVariable.safeName(name)
-
-    bind.find(_.name == safeName) match {
-      case Some(_) => uniqueBindName(s"${safeName}${bind.size + 1}")
-      case None => safeName
-    }
+    SQL(sql()).on(bindVariables.variables.map(_.toNamedParameter): _*)
   }
 
   private[this] def withFunctions[T](

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -480,33 +480,33 @@ case class Query(
       bindVar match {
         case BindVariable.Int(name, value) => {
           query.
-            replace(bindVar.sql, value.toString).
+            replace(bindVar.sqlPlaceholder, value.toString).
             replace(s"{$name}", value.toString)
         }
         case BindVariable.BigInt(name, value) => {
           query.
-            replace(bindVar.sql, value.toString).
+            replace(bindVar.sqlPlaceholder, value.toString).
             replace(s"{$name}", value.toString)
         }
         case BindVariable.Num(name, value) => {
           query.
-            replace(bindVar.sql, value.toString).
+            replace(bindVar.sqlPlaceholder, value.toString).
             replace(s"{$name}", value.toString)
         }
         case BindVariable.Uuid(_, value) => {
-          query.replace(bindVar.sql, s"'$value'::uuid")
+          query.replace(bindVar.sqlPlaceholder, s"'$value'::uuid")
         }
         case BindVariable.DateVar(_, value) => {
-          query.replace(bindVar.sql, s"'$value'::date")
+          query.replace(bindVar.sqlPlaceholder, s"'$value'::date")
         }
         case BindVariable.DateTimeVar(_, value) => {
-          query.replace(bindVar.sql, s"'$value'::timestamptz")
+          query.replace(bindVar.sqlPlaceholder, s"'$value'::timestamptz")
         }
         case BindVariable.Str(_, value) => {
-          query.replace(bindVar.sql, s"'$value'")
+          query.replace(bindVar.sqlPlaceholder, s"'$value'")
         }
         case BindVariable.Unit(_) => {
-          query.replace(bindVar.sql, "null")
+          query.replace(bindVar.sqlPlaceholder, "null")
         }
       }
     }
@@ -527,7 +527,7 @@ case class Query(
 
           case bindVar :: Nil if c.operator != "in" && c.operator != "not in" => {
             val exprColumn = withFunctions(c.column, c.columnFunctions, bindVar.value)
-            val exprValue = withFunctions(bindVar.sql, c.valueFunctions ++ bindVar.defaultValueFunctions, bindVar.value)
+            val exprValue = withFunctions(bindVar.sqlPlaceholder, c.valueFunctions ++ bindVar.defaultValueFunctions, bindVar.value)
             s"$exprColumn ${c.operator} $exprValue"
           }
 
@@ -536,7 +536,7 @@ case class Query(
 
             s"$exprColumn ${c.operator} (%s)".format(
               multiple.map { bindVar =>
-                withFunctions(bindVar.sql, c.valueFunctions ++ bindVar.defaultValueFunctions, multiple.head)
+                withFunctions(bindVar.sqlPlaceholder, c.valueFunctions ++ bindVar.defaultValueFunctions, multiple.head)
               }.mkString(", ")
             )
           }

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -293,13 +293,13 @@ case class Query(
     name: String,
     value: T
   ): Query = {
-    assert(
-      !explicitBindVariables.exists(_.name == name),
-      s"Bind variable named '$name' already defined"
-    )
     val safe = BindVariable.safeName(name)
     assert(
-      safe == name,
+      !explicitBindVariables.exists { bv => BindVariable.safeName(bv.name) == safe },
+      s"Bind variable named '$name' already defined"
+    )
+    assert(
+      safe == name.toLowerCase.trim,
       s"Invalid bind variable name[$name]" + (
         if (safe == BindVariable.DefaultBindName) { "" } else { s" suggest: $safe" }
       )

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -88,7 +88,7 @@ case class Query(
     columnFunctions: Seq[Query.Function] = Nil,
     valueFunctions: Seq[Query.Function] = Nil
   ): Query = {
-    val bindVar = BindVariables.createWithUniqueName(column, value)
+    val bindVar = BindVariables.createWithUniqueName(bind, column, value)
     val exprColumn = withFunctions(column, columnFunctions, value)
     val exprValue = withFunctions(bindVar.sql, valueFunctions ++ bindVar.defaultValueFunctions, value)
 
@@ -173,7 +173,7 @@ case class Query(
       }
       case multiple => {
         val variables = multiple.map { value =>
-          BindVariables.createWithUniqueName(column, value)
+          BindVariables.createWithUniqueName(bind, column, value)
         }
 
         val exprColumn = withFunctions(column, columnFunctions, multiple.head)

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -124,12 +124,19 @@ case class Query(
   }
 
   def in[T](
-    column: String,
-    values: Seq[T],
-    columnFunctions: Seq[Query.Function] = Nil,
-    valueFunctions: Seq[Query.Function] = Nil
-  ): Query = {
+             column: String,
+             values: Seq[T],
+             columnFunctions: Seq[Query.Function] = Nil,
+             valueFunctions: Seq[Query.Function] = Nil
+           ): Query = {
     inClauseBuilder("in", column, values, columnFunctions, valueFunctions)
+  }
+
+  def in[T](
+    column: String,
+    query: Query
+  ): Query = {
+
   }
 
   def optionalNotIn[T](
@@ -191,6 +198,11 @@ case class Query(
         )
       }
     }
+  }
+
+  def or(
+          clauses: Seq[Query]
+        ): Query = {
   }
 
   def or(

--- a/src/test/scala/io/flow/postgresql/BulkDeleteSpec.scala
+++ b/src/test/scala/io/flow/postgresql/BulkDeleteSpec.scala
@@ -34,7 +34,6 @@ class BulkDeleteSpec extends FunSpec with Matchers {
     var found = scala.collection.mutable.ListBuffer[Int]()
 
     BulkDelete.byPage {
-      println("ADSFASDF")
       items
     } { e =>
       found += e

--- a/src/test/scala/io/flow/postgresql/LastIdPagerSpec.scala
+++ b/src/test/scala/io/flow/postgresql/LastIdPagerSpec.scala
@@ -18,6 +18,7 @@ class LastIdPagerSpec extends FunSpec with Matchers {
       {
         case None => Seq("*", "**")
         case Some(2L) => Nil
+        case other => sys.error(s"unexpected value: $other")
       },
       _.size
     )
@@ -35,6 +36,7 @@ class LastIdPagerSpec extends FunSpec with Matchers {
         case None => Seq("*", "**")
         case Some(2L) => Seq("****")
         case Some(4L) => Nil
+        case other => sys.error(s"unexpected value: $other")
       },
       _.size
     )

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -673,7 +673,7 @@ class QuerySpec extends FunSpec with Matchers {
 
   it("queries that share bind variables (note status2 in bind key)") {
     val a = Query("select * from users").equals("status", "live")
-    val b = Query("select id from users", bindVariables = a.bindVariables).equals("status", "draft")
+    val b = Query("select id from users", bind = a.bind).equals("status", "draft")
 
     validate(
       a.and(s"id in (${b.sql()})"),

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -494,10 +494,20 @@ class QuerySpec extends FunSpec with Matchers {
     )
   }
 
+  it("nested bind variables work") {
+    validate(
+      Query("select * from users").
+        bind("user.email", "mike@flow.io").
+        bind("email", Some("paolo@flow.io")),
+      "select * from users where users.email = trim({email2})",
+      "select * from users where users.email = trim('mike@flow.io')"
+    )
+  }
+
   it("bind with duplicate variable name raises an error") {
     Try {
       Query("select * from users").
-        text("users.email", Some("mike@flow.io")).
+        bind("email", "mike@flow.io").
         bind("email", Some("paolo@flow.io"))
     } match {
       case Success(_) => fail("Expected error for duplicate bind variable")
@@ -671,16 +681,15 @@ class QuerySpec extends FunSpec with Matchers {
     )
   }
 
+  /*TODO
   it("queries that share bind variables (note status2 in bind key)") {
     val experience = Query("select * from experiences")
     val liveFilter = Query("select id from experiences").equals("status", "draft")
     val draftFilter = Query("select id from experiences").equals("status", "live")
 
-
-
     validate(
       experience.copy(
-        bind = experience.bind ++ liveFilter.bind ++ draftFilter.bind
+        explicitBindVariables = experience.bind ++ liveFilter.bind ++ draftFilter.bind
       ).or(
         Seq(
           "experience.id in (${liveFilter.sql()})",
@@ -691,5 +700,6 @@ class QuerySpec extends FunSpec with Matchers {
       "select * from users where status = trim('live') and id in (select id from users where status = trim('draft'))"
     )
   }
+  */
 
 }

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -496,10 +496,9 @@ class QuerySpec extends FunSpec with Matchers {
 
   it("nested bind variables work") {
     validate(
-      Query("select * from users").
-        bind("user.email", "mike@flow.io").
-        bind("email", Some("paolo@flow.io")),
-      "select * from users where users.email = trim({email2})",
+      Query("select * from users where email = {email}").
+        bind("user.email", "mike@flow.io"),
+      "select * from users where users.email = trim({email})",
       "select * from users where users.email = trim('mike@flow.io')"
     )
   }

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -507,11 +507,11 @@ class QuerySpec extends FunSpec with Matchers {
     Try {
       Query("select * from users").
         bind("email", "mike@flow.io").
-        bind("email", Some("paolo@flow.io"))
+        bind("EMAIL", Some("paolo@flow.io"))
     } match {
       case Success(_) => fail("Expected error for duplicate bind variable")
       case Failure(ex) => {
-        ex.getMessage should be("assertion failed: Bind variable named 'email' already defined")
+        ex.getMessage should be("assertion failed: Bind variable named 'EMAIL' already defined")
       }
     }
   }

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -497,9 +497,9 @@ class QuerySpec extends FunSpec with Matchers {
   it("nested bind variables work") {
     validate(
       Query("select * from users where email = {email}").
-        bind("user.email", "mike@flow.io"),
-      "select * from users where users.email = trim({email})",
-      "select * from users where users.email = trim('mike@flow.io')"
+        bind("email", "mike@flow.io"),
+      "select * from users where email = {email}",
+      "select * from users where email = 'mike@flow.io'"
     )
   }
 
@@ -512,6 +512,28 @@ class QuerySpec extends FunSpec with Matchers {
       case Success(_) => fail("Expected error for duplicate bind variable")
       case Failure(ex) => {
         ex.getMessage should be("assertion failed: Bind variable named 'email' already defined")
+      }
+    }
+  }
+
+  it("bind validates name is safe") {
+    Try {
+      Query("select * from users").
+        bind("!@#", "mike@flow.io")
+    } match {
+      case Success(_) => fail("Expected error for duplicate bind variable")
+      case Failure(ex) => {
+        ex.getMessage should be("assertion failed: Invalid bind variable name[!@#]")
+      }
+    }
+
+    Try {
+      Query("select * from users").
+        bind("user.email", "mike@flow.io")
+    } match {
+      case Success(_) => fail("Expected error for duplicate bind variable")
+      case Failure(ex) => {
+        ex.getMessage should be("assertion failed: Invalid bind variable name[user.email] suggest: email")
       }
     }
   }

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -502,7 +502,7 @@ class QuerySpec extends FunSpec with Matchers {
     } match {
       case Success(_) => fail("Expected error for duplicate bind variable")
       case Failure(ex) => {
-        ex.getMessage should be("Bind variable named 'email' already defined")
+        ex.getMessage should be("assertion failed: Bind variable named 'email' already defined")
       }
     }
   }
@@ -668,6 +668,17 @@ class QuerySpec extends FunSpec with Matchers {
         "Interpolated:",
         "select * from users where id = 5"
       ).mkString("\n")
+    )
+  }
+
+  it("queries that share bind variables (note status2 in bind key)") {
+    val a = Query("select * from users").equals("status", "live")
+    val b = Query("select id from users", bindVariables = a.bindVariables).equals("status", "draft")
+
+    validate(
+      a.and(s"id in (${b.sql()})"),
+      "select * from users where status = trim({status}) and id in (select id from users where status = trim({status2}))",
+      "select * from users where status = trim('live') and id in (select id from users where status = trim('draft'))"
     )
   }
 


### PR DESCRIPTION
- more deterministic in preventing conflicts on bind variable names
  - sets up ground work for nesting queries