### PR TITLE
Sanitize: Expose sanitize method to enable checking if input is safe

### DIFF
--- a/src/main/scala/io/flow/postgresql/OrderBy.scala
+++ b/src/main/scala/io/flow/postgresql/OrderBy.scala
@@ -19,9 +19,8 @@ case class OrderBy(clauses: Seq[String]) {
 
 object OrderBy {
 
-  private[this] val ValidCharacters = "_,.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".split("").toSet
-  val ValidFunctions = Seq("abs", "lower", "json")
-  val ValidOrderOperators = Seq("-", "+")
+  val ValidFunctions: Set[String] = Set("abs", "lower", "json")
+  val ValidOrderOperators: Set[String] = Set("-", "+")
 
   def parse(
     value: String,
@@ -34,7 +33,7 @@ object OrderBy {
       case allClauses => {
         val clauses = allClauses.map(removeOrder).map(removeFunctions)
         clauses.find { c =>
-          c.split("").exists(!ValidCharacters.contains(_))
+          !Sanitize.isSafe(c)
         } match {
           case None => {
             val parsed: Seq[Either[String, Clause]] = allClauses.map { parseDirection(_, defaultTable) }
@@ -48,7 +47,7 @@ object OrderBy {
             }
           }
           case Some(_) => {
-            val chars = value.split("").filter(!ValidCharacters.contains(_)).distinct
+            val chars = value.split("").filter(!Sanitize.ValidCharacters.contains(_)).distinct
             Left(
               Seq(
                 s"Sort[$value] contains invalid characters: " + chars.mkString("'", "', '", "'")

--- a/src/main/scala/io/flow/postgresql/Sanitize.scala
+++ b/src/main/scala/io/flow/postgresql/Sanitize.scala
@@ -1,0 +1,15 @@
+package io.flow.postgresql
+
+object Sanitize {
+
+  val ValidCharacters: Set[String] = "_-,.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".split("").toSet
+
+  /**
+    * Returns true IFF the string contains only safe
+    * characters
+    */
+  def isSafe(value: String): Boolean = {
+    value.trim.split("").forall(ValidCharacters.contains)
+  }
+
+}

--- a/src/test/scala/io/flow/postgresql/OrderBySpec.scala
+++ b/src/test/scala/io/flow/postgresql/OrderBySpec.scala
@@ -115,7 +115,7 @@ class OrderBySpec extends FunSpec with Matchers {
     )
 
     OrderBy.parse("name,name||pg_sleep(5)--") should be(
-      Left(Seq("Sort[name,name||pg_sleep(5)--] contains invalid characters: '|', '(', ')'w"))
+      Left(Seq("Sort[name,name||pg_sleep(5)--] contains invalid characters: '|', '(', ')'"))
     )
   }
 

--- a/src/test/scala/io/flow/postgresql/OrderBySpec.scala
+++ b/src/test/scala/io/flow/postgresql/OrderBySpec.scala
@@ -115,7 +115,7 @@ class OrderBySpec extends FunSpec with Matchers {
     )
 
     OrderBy.parse("name,name||pg_sleep(5)--") should be(
-      Left(Seq("Sort[name,name||pg_sleep(5)--] contains invalid characters: '|', '(', ')'"))
+      Left(Seq("Sort[name,name||pg_sleep(5)--] contains invalid characters: '|', '(', ')'w"))
     )
   }
 

--- a/src/test/scala/io/flow/postgresql/OrderBySpec.scala
+++ b/src/test/scala/io/flow/postgresql/OrderBySpec.scala
@@ -115,7 +115,7 @@ class OrderBySpec extends FunSpec with Matchers {
     )
 
     OrderBy.parse("name,name||pg_sleep(5)--") should be(
-      Left(Seq("Sort[name,name||pg_sleep(5)--] contains invalid characters: '|', '(', ')', '-'"))
+      Left(Seq("Sort[name,name||pg_sleep(5)--] contains invalid characters: '|', '(', ')'"))
     )
   }
 

--- a/src/test/scala/io/flow/postgresql/SanitizeSpec.scala
+++ b/src/test/scala/io/flow/postgresql/SanitizeSpec.scala
@@ -1,0 +1,13 @@
+package io.flow.postgresql
+
+import org.scalatest.{FunSpec, Matchers}
+
+class SanitizeSpec extends FunSpec with Matchers {
+
+  it("prevents sql injection") {
+    Sanitize.isSafe("foo") should be(true)
+    Sanitize.isSafe("drop table users") should be(false)
+    Sanitize.isSafe("name,name||pg_sleep(5)--") should be(false)
+  }
+
+}


### PR DESCRIPTION
 - whitelist '-' as a safe character to handle our ids (e.g. `usr-xxx`)