### PR TITLE
FDN-2249 Add support for multiple columns queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,5 @@ Parsing is based on anorm parser.
 
 ```scala
 val q = Query("SELECT id, name FROM organizations")
-val res: List[(String, String)] = q.as((str("id") ~ str("name")).*) .map {
-  case id ~ name => (id, name)
-}
+val res: List[(String, String)] = q.as((str("id") ~ str("name")).*).map { case id ~ name => (id, name) }
 ```

--- a/README.md
+++ b/README.md
@@ -69,3 +69,85 @@ Then edit install.sh, replacing <NAME> with the name of your project.
 
     git add install.sh Dockerfile
     git commit -m "Add Dockerfile"
+
+## Query 
+
+`Query` is a wrapper around anorm to allow the creation of sql queries in a more functional way.
+
+### Column functions:
+
+```scala
+val q = Query("SELECT * FROM organizations")
+val q1 = q.equals("id", "org1")
+val q1 = q.isTrue("processed")
+val q2 = q.isNull("parent_id")
+val q3 = q.notEquals("id", "org1")
+
+val q4 = q.in("id", Seq("org1", "org2"))
+val q5 = q.isTrue("processed")
+
+val q6 = q.notIn("id", Seq("org1", "org2"))
+val q7 = q.in2(("id", "name"), Seq(("o1", "n1"), ("o2", "n2"), ("o3", "n3")))
+val q8 = q.in3(("id", "name", "key"), Seq(("o1", "n1", "k1"), ("o2", "n2", "k2"), ("o3", "n3", "k3")))
+
+// Option
+val q1 = q.equals("id", Some("org1"))
+val q2 = q.notEquals("id", Some("org1"))
+
+val q3 = q.inOptional("id", Some(Seq("org1", "org2")))
+val q4 = q.notInOptional("id", Some(Seq("org1", "org2")))
+
+val q5 = q.in2Optional(("id", "name"), Some(Seq(("o1", "n1"), ("o2", "n2"), ("o3", "n3"))))
+val q6 = q.in3Optional(("id", "name", "key"), Some(Seq(("o1", "n1", "k1"), ("o2", "n2", "k2"), ("o3", "n3", "k3"))))
+
+// If the value is None, the condition is ignored
+
+// Less / Greater than
+val q1 = q.lessThan("counter", 10)
+val q2 = q.greaterThan("created_at", DateTime.now().minusDays(1))
+
+
+```
+
+### Subquery
+
+```scala
+val q = Query("SELECT * FROM organizations")
+
+// And / Or
+val q1 = q.or(Seq("parent_id is null", "channel_id is null"))
+// SELECT * FROM organizations where parent_id is null or channel_id is null
+
+val q2 = q.and(Seq("parent_id is null", "channel_id is null"))
+// SELECT * FROM organizations where parent_id is null and channel_id is null
+
+val actives = Query("SELECT * FROM organizations").equals("status", "active")
+val webs = Query("SELECT id FROM organizations").equals("channel", "web")
+val q1 = actives.notIn("id", webs)
+// "SELECT * FROM organizations where status = trim('active') and id not in (select id from experiences where channel = trim('web'))"
+```
+
+### Custom bindings
+
+```scala
+// Define your own bindings
+val id = "org1"
+val name = "test"
+
+// Use the bindings in the SQL query
+val query = Query(s"SELECT * FROM organizations WHERE id = {id} AND name = {name}")
+
+// Bind the variables
+val bound: Query = query.bind("id", id).bind("name" -> name)
+```
+
+### Parsing results
+
+Parsing is based on anorm parser.
+
+```scala
+val q = Query("SELECT id, name FROM organizations")
+val res: List[(String, String)] = q.as((str("id") ~ str("name")).*) .map {
+  case id ~ name => (id, name)
+}
+```

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -297,15 +297,130 @@ case class Query(
       case Some(v) => inMulti(columns, v, columnFunctions, valueFunctions)
     }
 
-  def in(column: String, query: Query): Query = {
+  def optionalIn2[T1, T2](
+    columns: (String, String),
+    values: Option[Seq[(T1, T2)]],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil)
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => in2(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalIn3[T1, T2, T3](
+    columns: (String, String, String),
+    values: Option[Seq[(T1, T2, T3)]],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil)
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => in3(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalIn4[T1, T2, T3, T4](
+    columns: (String, String, String, String),
+    values: Option[Seq[(T1, T2, T3, T4)]],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => in4(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalIn5[T1, T2, T3, T4, T5](
+    columns: (String, String, String, String, String),
+    values: Option[Seq[(T1, T2, T3, T4, T5)]],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => in5(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalIn6[T1, T2, T3, T4, T5, T6](
+    columns: (String, String, String, String, String, String),
+    values: Option[Seq[(T1, T2, T3, T4, T5, T6)]],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => in6(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def in(column: String, query: Query): Query =
     addSubquery(column, query, "in")
-  }
 
-  def notIn(column: String, query: Query): Query = {
+  def notIn(column: String, query: Query): Query =
     addSubquery(column, query, "not in")
-  }
 
-  private[this] def addSubquery(column: String, query: Query, operator: String): Query = {
+  private[this] def addSubquery(column: String, query: Query, operator: String): Query =
     this.copy(
       conditions = conditions ++ Seq(
         QueryCondition.Subquery(
@@ -315,7 +430,6 @@ case class Query(
         )
       )
     )
-  }
 
   def in[T](
     column: String,
@@ -333,6 +447,118 @@ case class Query(
     valueFunctions: Seq[Seq[Query.Function]] = Nil
   ): Query =
     inMultipleClauseBuilder("in", columns, values, columnFunctions, valueFunctions)
+
+  def in2[T1, T2](
+    columns: (String, String),
+    values: Seq[(T1, T2)],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil)
+  ): Query =
+    inMultipleClauseBuilder(
+      "in",
+      Seq(columns._1, columns._2),
+      values.map { case (v1, v2) => Seq[Any](v1, v2) },
+      Seq(columnFunctions._1, columnFunctions._2),
+      Seq(valueFunctions._1, valueFunctions._2)
+    )
+
+  def in3[T1, T2, T3](
+    columns: (String, String, String),
+    values: Seq[(T1, T2, T3)],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil)
+  ): Query =
+    inMultipleClauseBuilder(
+      "in",
+      Seq(columns._1, columns._2, columns._3),
+      values.map { case (v1, v2, v3) => Seq[Any](v1, v2, v3) },
+      Seq(columnFunctions._1, columnFunctions._2, columnFunctions._3),
+      Seq(valueFunctions._1, valueFunctions._2, valueFunctions._3)
+    )
+
+  def in4[T1, T2, T3, T4](
+    columns: (String, String, String, String),
+    values: Seq[(T1, T2, T3, T4)],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) =
+      (Nil, Nil, Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) =
+      (Nil, Nil, Nil, Nil)
+  ): Query =
+    inMultipleClauseBuilder(
+      "in",
+      Seq(columns._1, columns._2, columns._3, columns._4),
+      values.map { case (v1, v2, v3, v4) => Seq[Any](v1, v2, v3, v4) },
+      Seq(columnFunctions._1, columnFunctions._2, columnFunctions._3, columnFunctions._4),
+      Seq(valueFunctions._1, valueFunctions._2, valueFunctions._3, valueFunctions._4)
+    )
+
+  def in5[T1, T2, T3, T4, T5](
+    columns: (String, String, String, String, String),
+    values: Seq[(T1, T2, T3, T4, T5)],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (Nil, Nil, Nil, Nil, Nil),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (Nil, Nil, Nil, Nil, Nil)
+  ): Query =
+    inMultipleClauseBuilder(
+      "in",
+      Seq(columns._1, columns._2, columns._3, columns._4, columns._5),
+      values.map { case (v1, v2, v3, v4, v5) => Seq[Any](v1, v2, v3, v4, v5) },
+      Seq(columnFunctions._1, columnFunctions._2, columnFunctions._3, columnFunctions._4, columnFunctions._5),
+      Seq(valueFunctions._1, valueFunctions._2, valueFunctions._3, valueFunctions._4, valueFunctions._5)
+    )
+
+  def in6[T1, T2, T3, T4, T5, T6](
+    columns: (String, String, String, String, String, String),
+    values: Seq[(T1, T2, T3, T4, T5, T6)],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (Nil, Nil, Nil, Nil, Nil, Nil),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (Nil, Nil, Nil, Nil, Nil, Nil)
+  ): Query =
+    inMultipleClauseBuilder(
+      "in",
+      Seq(columns._1, columns._2, columns._3, columns._4, columns._5, columns._6),
+      values.map { case (v1, v2, v3, v4, v5, v6) => Seq[Any](v1, v2, v3, v4, v5, v6) },
+      Seq(
+        columnFunctions._1,
+        columnFunctions._2,
+        columnFunctions._3,
+        columnFunctions._4,
+        columnFunctions._5,
+        columnFunctions._6
+      ),
+      Seq(
+        valueFunctions._1,
+        valueFunctions._2,
+        valueFunctions._3,
+        valueFunctions._4,
+        valueFunctions._5,
+        valueFunctions._6
+      )
+    )
 
   def optionalNotIn[T](
     column: String,
@@ -357,6 +583,123 @@ case class Query(
       case Some(v) => notInMulti(columns, v, columnFunctions, valueFunctions)
     }
 
+  def optionalNotIn2[T1, T2](
+    columns: (String, String),
+    values: Option[Seq[(T1, T2)]],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil)
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => notIn2(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalNotIn3[T1, T2, T3](
+    columns: (String, String, String),
+    values: Option[Seq[(T1, T2, T3)]],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil)
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => notIn3(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalNotIn4[T1, T2, T3, T4](
+    columns: (String, String, String, String),
+    values: Option[Seq[(T1, T2, T3, T4)]],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => notIn4(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalNotIn5[T1, T2, T3, T4, T5](
+    columns: (String, String, String, String, String),
+    values: Option[Seq[(T1, T2, T3, T4, T5)]],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => notIn5(columns, v, columnFunctions, valueFunctions)
+    }
+
+  def optionalNotIn6[T1, T2, T3, T4, T5, T6](
+    columns: (String, String, String, String, String, String),
+    values: Option[Seq[(T1, T2, T3, T4, T5, T6)]],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    values match {
+      case None => this
+      case Some(v) => notIn6(columns, v, columnFunctions, valueFunctions)
+    }
+
   def notIn[T](
     column: String,
     values: Seq[T],
@@ -372,6 +715,152 @@ case class Query(
     valueFunctions: Seq[Seq[Query.Function]] = Nil
   ): Query =
     inMultipleClauseBuilder("not in", columns, values, columnFunctions, valueFunctions)
+
+  def notIn2[T1, T2](
+    columns: (String, String),
+    values: Seq[(T1, T2)],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil)
+  ): Query =
+    inMultipleClauseBuilder(
+      "not in",
+      Seq(columns._1, columns._2),
+      values.map { case (v1, v2) => Seq[Any](v1, v2) },
+      Seq(columnFunctions._1, columnFunctions._2),
+      Seq(valueFunctions._1, valueFunctions._2)
+    )
+
+  def notIn3[T1, T2, T3](
+    columns: (String, String, String),
+    values: Seq[(T1, T2, T3)],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (Nil, Nil, Nil)
+  ): Query =
+    inMultipleClauseBuilder(
+      "not in",
+      Seq(columns._1, columns._2, columns._3),
+      values.map { case (v1, v2, v3) => Seq[Any](v1, v2, v3) },
+      Seq(columnFunctions._1, columnFunctions._2, columnFunctions._3),
+      Seq(valueFunctions._1, valueFunctions._2, valueFunctions._3)
+    )
+
+  def notIn4[T1, T2, T3, T4](
+    columns: (String, String, String, String),
+    values: Seq[(T1, T2, T3, T4)],
+    columnFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (Seq[Query.Function], Seq[Query.Function], Seq[Query.Function], Seq[Query.Function]) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    inMultipleClauseBuilder(
+      "not in",
+      Seq(columns._1, columns._2, columns._3, columns._4),
+      values.map { case (v1, v2, v3, v4) => Seq[Any](v1, v2, v3, v4) },
+      Seq(columnFunctions._1, columnFunctions._2, columnFunctions._3, columnFunctions._4),
+      Seq(valueFunctions._1, valueFunctions._2, valueFunctions._3, valueFunctions._4)
+    )
+
+  def notIn5[T1, T2, T3, T4, T5](
+    columns: (String, String, String, String, String),
+    values: Seq[(T1, T2, T3, T4, T5)],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    inMultipleClauseBuilder(
+      "not in",
+      Seq(columns._1, columns._2, columns._3, columns._4, columns._5),
+      values.map { case (v1, v2, v3, v4, v5) => Seq[Any](v1, v2, v3, v4, v5) },
+      Seq(columnFunctions._1, columnFunctions._2, columnFunctions._3, columnFunctions._4, columnFunctions._5),
+      Seq(valueFunctions._1, valueFunctions._2, valueFunctions._3, valueFunctions._4, valueFunctions._5)
+    )
+
+  def notIn6[T1, T2, T3, T4, T5, T6](
+    columns: (String, String, String, String, String, String),
+    values: Seq[(T1, T2, T3, T4, T5, T6)],
+    columnFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    ),
+    valueFunctions: (
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function],
+      Seq[Query.Function]
+    ) = (
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil
+    )
+  ): Query =
+    inMultipleClauseBuilder(
+      "not in",
+      Seq(columns._1, columns._2, columns._3, columns._4, columns._5, columns._6),
+      values.map { case (v1, v2, v3, v4, v5, v6) => Seq[Any](v1, v2, v3, v4, v5, v6) },
+      Seq(
+        columnFunctions._1,
+        columnFunctions._2,
+        columnFunctions._3,
+        columnFunctions._4,
+        columnFunctions._5,
+        columnFunctions._6
+      ),
+      Seq(
+        valueFunctions._1,
+        valueFunctions._2,
+        valueFunctions._3,
+        valueFunctions._4,
+        valueFunctions._5,
+        valueFunctions._6
+      )
+    )
 
   private[this] def inClauseBuilder[T](
     operator: String,
@@ -766,12 +1255,13 @@ case class Query(
 
           case bindVar :: Nil if c.operator != "in" && c.operator != "not in" => {
             val exprColumn = withFunctionsMultiple(c.columns, c.columnFunctions, bindVar.map(_.value))
+            val functions =
+              bindVar
+                .map(_.defaultValueFunctions)
+                .zipAll[Seq[Query.Function], Seq[Query.Function]](c.valueFunctions, Seq.empty, Seq.empty)
+                .map { case (df, vf) => vf ++ df }
             val exprValue =
-              withFunctionsMultiple(
-                names = bindVar.map(_.sqlPlaceholder),
-                functions = c.valueFunctions ++ bindVar.map(_.defaultValueFunctions),
-                values = bindVar.map(_.value)
-              )
+              withFunctionsMultiple(bindVar.map(_.sqlPlaceholder), functions, bindVar.map(_.value))
             s"$exprColumn ${c.operator} $exprValue"
           }
 
@@ -781,11 +1271,12 @@ case class Query(
             s"$exprColumn ${c.operator} (%s)".format(
               multiple
                 .map { bindVar =>
-                  withFunctionsMultiple(
-                    names = bindVar.map(_.sqlPlaceholder),
-                    functions = c.valueFunctions ++ bindVar.map(_.defaultValueFunctions),
-                    values = values
-                  )
+                  val functions =
+                    bindVar
+                      .map(_.defaultValueFunctions)
+                      .zipAll[Seq[Query.Function], Seq[Query.Function]](c.valueFunctions, Seq.empty, Seq.empty)
+                      .map { case (df, vf) => vf ++ df }
+                  withFunctionsMultiple(bindVar.map(_.sqlPlaceholder), functions, values)
                 }
                 .mkString(", ")
             )
@@ -854,7 +1345,7 @@ case class Query(
   ): String =
     applicableFunctions(functions, value).distinct.reverse.foldLeft(name) { case (acc, function) => s"$function($acc)" }
 
-  /** Apply functions to the column or value in the query. A common use case is to apply (lower(trim(n1)),
+  /** Apply functions to the column or value in the query. An example use case is to apply (lower(trim(n1)),
     * lower(trim(n2))) to enable case insensitive text matching.
     */
   private[this] def withFunctionsMultiple[T](
@@ -877,12 +1368,11 @@ case class Query(
   private[this] def applicableFunctions[T](
     functions: Seq[Query.Function],
     value: T
-  ): Seq[Query.Function] = {
+  ): Seq[Query.Function] =
     value match {
       case None | _: UUID | _: LocalDate | _: DateTime | _: Int | _: Long | _: Number | _: Unit => Nil
       case Some(v) => applicableFunctions(functions, v)
       case _ => functions
     }
-  }
 
 }

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -286,9 +286,9 @@ case class Query(
     }
   }
 
-  def optionalInMulti[T](
+  def optionalInMulti(
     columns: Seq[String],
-    values: Option[Seq[Seq[T]]],
+    values: Option[Seq[Seq[_]]],
     columnFunctions: Seq[Seq[Query.Function]] = Nil,
     valueFunctions: Seq[Seq[Query.Function]] = Nil
   ): Query =
@@ -440,9 +440,9 @@ case class Query(
     inClauseBuilder("in", column, values, columnFunctions, valueFunctions)
   }
 
-  def inMulti[T](
+  def inMulti(
     columns: Seq[String],
-    values: Seq[Seq[T]],
+    values: Seq[Seq[_]],
     columnFunctions: Seq[Seq[Query.Function]] = Nil,
     valueFunctions: Seq[Seq[Query.Function]] = Nil
   ): Query =
@@ -572,9 +572,9 @@ case class Query(
     }
   }
 
-  def optionalNotInMulti[T](
+  def optionalNotInMulti(
     columns: Seq[String],
-    values: Option[Seq[Seq[T]]],
+    values: Option[Seq[Seq[_]]],
     columnFunctions: Seq[Seq[Query.Function]] = Nil,
     valueFunctions: Seq[Seq[Query.Function]] = Nil
   ): Query =
@@ -708,9 +708,9 @@ case class Query(
   ): Query =
     inClauseBuilder("not in", column, values, columnFunctions, valueFunctions)
 
-  def notInMulti[T](
+  def notInMulti(
     columns: Seq[String],
-    values: Seq[Seq[T]],
+    values: Seq[Seq[_]],
     columnFunctions: Seq[Seq[Query.Function]] = Nil,
     valueFunctions: Seq[Seq[Query.Function]] = Nil
   ): Query =

--- a/src/main/scala/io/flow/postgresql/Query.scala
+++ b/src/main/scala/io/flow/postgresql/Query.scala
@@ -411,7 +411,8 @@ case class Query(
     )
     values.zipWithIndex.find { case (vs, _) => vs.size != columns.size }.map { case (vs, i) => (i, vs.size) } match {
       case Some((i, size)) =>
-        val msg = s"Invalid number of values at index $i: values[$i].size = $size while columns.size = ${columns.size}]"
+        val msg = s"Invalid number of values at index $i: columns.size = ${columns.size} but values[$i].size = $size." +
+          s" You must provide as many values as columns."
         throw new java.lang.AssertionError(msg)
       case None =>
         this.copy(

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -287,6 +287,116 @@ class QuerySpec extends AnyFunSpec with Matchers {
     )
   }
 
+  it("in multi") {
+    validate(
+      Query("select * from users").optionalInMulti(Seq("org", "email"), None),
+      "select * from users",
+      "select * from users"
+    )
+
+    validate(
+      Query("select * from users").optionalInMulti(Seq("org", "email"), Some(Nil)),
+      "select * from users where false",
+      "select * from users where false"
+    )
+
+    validate(
+      Query("select * from users").inMulti(Seq("org", "email"), Seq(Seq("org1", "jean@flow.io"))),
+      "select * from users where (org, email) in ((trim({org}), trim({email})))",
+      "select * from users where (org, email) in ((trim('org1'), trim('jean@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users")
+        .inMulti(Seq("org", "email"), Seq(Seq("org1", "jean@flow.io"), Seq("org2", "mike@flow.io"))),
+      "select * from users where (org, email) in ((trim({org}), trim({email})), (trim({org2}), trim({email2})))",
+      "select * from users where (org, email) in ((trim('org1'), trim('jean@flow.io')), (trim('org2'), trim('mike@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users")
+        .inMulti(Seq("org", "users.email"), Seq(Seq("org1", "jean@flow.io"), Seq("org2", "mike@flow.io"))),
+      "select * from users where (org, users.email) in ((trim({org}), trim({email})), (trim({org2}), trim({email2})))",
+      "select * from users where (org, users.email) in ((trim('org1'), trim('jean@flow.io')), (trim('org2'), trim('mike@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users").inMulti(
+        Seq("users.email", "table.json->>'jsonfield'"),
+        Seq(Seq("j@flow.io", "jsonvalue"), Seq("m@flow.io", "jsonvalue2"))
+      ),
+      "select * from users where (users.email, table.json->>'jsonfield') in ((trim({email}), trim({json_jsonfield})), (trim({email2}), trim({json_jsonfield_2})))",
+      "select * from users where (users.email, table.json->>'jsonfield') in ((trim('j@flow.io'), trim('jsonvalue')), (trim('m@flow.io'), trim('jsonvalue2')))"
+    )
+  }
+
+  it("not in multiple") {
+    validate(
+      Query("select * from users").optionalNotIn("email", None),
+      "select * from users",
+      "select * from users"
+    )
+
+    validate(
+      Query("select * from users").optionalNotIn("email", Some(Nil)),
+      "select * from users where false",
+      "select * from users where false"
+    )
+
+    validate(
+      Query("select * from users").notInMulti(Seq("org", "email"), Seq(Seq("org1", "jean@flow.io"))),
+      "select * from users where (org, email) not in ((trim({org}), trim({email})))",
+      "select * from users where (org, email) not in ((trim('org1'), trim('jean@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users")
+        .notInMulti(Seq("org", "email"), Seq(Seq("org1", "jean@flow.io"), Seq("org2", "mike@flow.io"))),
+      "select * from users where (org, email) not in ((trim({org}), trim({email})), (trim({org2}), trim({email2})))",
+      "select * from users where (org, email) not in ((trim('org1'), trim('jean@flow.io')), (trim('org2'), trim('mike@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users")
+        .notInMulti(Seq("org", "users.email"), Seq(Seq("org1", "jean@flow.io"), Seq("org2", "mike@flow.io"))),
+      "select * from users where (org, users.email) not in ((trim({org}), trim({email})), (trim({org2}), trim({email2})))",
+      "select * from users where (org, users.email) not in ((trim('org1'), trim('jean@flow.io')), (trim('org2'), trim('mike@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users").notInMulti(
+        Seq("users.email", "table.json->>'jsonfield'"),
+        Seq(Seq("j@flow.io", "jsonvalue"), Seq("m@flow.io", "jsonvalue2"))
+      ),
+      "select * from users where (users.email, table.json->>'jsonfield') not in ((trim({email}), trim({json_jsonfield})), (trim({email2}), trim({json_jsonfield_2})))",
+      "select * from users where (users.email, table.json->>'jsonfield') not in ((trim('j@flow.io'), trim('jsonvalue')), (trim('m@flow.io'), trim('jsonvalue2')))"
+    )
+  }
+
+  it("in multiple with datetime") {
+    val ts = DateTime.now
+    val values = Seq(Seq("org1", ts), Seq("org2", ts.plusHours(1)))
+    val extrapolated = values.collect { case Seq(v0, v1) => s"(trim('$v0'), '$v1'::timestamptz)" }.mkString(", ")
+    validate(
+      Query("select * from users").inMulti(Seq("org", "created_at"), values),
+      "select * from users where (org, created_at) in ((trim({org}), {created_at}::timestamptz), (trim({org2}), {created_at2}::timestamptz))",
+      "select * from users where (org, created_at) in (" + extrapolated + ")"
+    )
+  }
+
+  it("in multiple with functions") {
+    validate(
+      Query("select * from users").inMulti(
+        Seq("id", "org"),
+        Seq(Seq("id1", "org1"), Seq("id2", "org2")),
+        columnFunctions = Seq(Seq(Query.Function.Lower), Seq(Query.Function.Upper)),
+        valueFunctions = Seq(Seq(Query.Function.Lower, Query.Function.Trim), Seq(Query.Function.Upper))
+      ),
+      "select * from users where (lower(id), upper(org)) in ((lower(trim({id})), upper({org})), (lower(trim({id2})), upper({org2})))",
+      "select * from users where (lower(id), upper(org)) in ((lower(trim('id1')), upper('org1')), (lower(trim('id2')), upper('org2')))"
+    )
+  }
+
   it("numbers") {
     validate(
       Query("select * from users").equals("age", None),

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -328,6 +328,12 @@ class QuerySpec extends AnyFunSpec with Matchers {
       "select * from users where (users.email, table.json->>'jsonfield') in ((trim({email}), trim({json_jsonfield})), (trim({email2}), trim({json_jsonfield_2})))",
       "select * from users where (users.email, table.json->>'jsonfield') in ((trim('j@flow.io'), trim('jsonvalue')), (trim('m@flow.io'), trim('jsonvalue2')))"
     )
+
+    a[AssertionError] should be thrownBy {
+      Query("select * from users")
+        .inMulti(Seq("org", "users.email"), Seq(Seq("org1", "jean@flow.io"), Seq("org2")))
+    }
+
   }
 
   it("not in multiple") {

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -335,6 +335,77 @@ class QuerySpec extends AnyFunSpec with Matchers {
 
   }
 
+  it("in2") {
+    validate(
+      Query("select * from users").in2(("org", "email"), Seq(("org1", "jean@flow.io"))),
+      "select * from users where (org, email) in ((trim({org}), trim({email})))",
+      "select * from users where (org, email) in ((trim('org1'), trim('jean@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users")
+        .in2(("org", "email"), Seq(("org1", "jean@flow.io"), ("org2", "mike@flow.io"))),
+      "select * from users where (org, email) in ((trim({org}), trim({email})), (trim({org2}), trim({email2})))",
+      "select * from users where (org, email) in ((trim('org1'), trim('jean@flow.io')), (trim('org2'), trim('mike@flow.io')))"
+    )
+
+    validate(
+      Query("select * from users").in2(
+        ("users.email", "table.json->>'jsonfield'"),
+        Seq(("j@flow.io", "jsonvalue"), ("m@flow.io", "jsonvalue2"))
+      ),
+      "select * from users where (users.email, table.json->>'jsonfield') in ((trim({email}), trim({json_jsonfield})), (trim({email2}), trim({json_jsonfield_2})))",
+      "select * from users where (users.email, table.json->>'jsonfield') in ((trim('j@flow.io'), trim('jsonvalue')), (trim('m@flow.io'), trim('jsonvalue2')))"
+    )
+  }
+
+  it("inN") {
+    val ts = DateTime.now()
+
+    validate(
+      Query("select * from users").in3(("c1", "c2", "c3"), Seq(("v1_1", ts, 31), ("v1_2", ts, 32))),
+      "select * from users where (c1, c2, c3) in ((trim({c1}), {c2}::timestamptz, {c3}::int), (trim({c12}), {c22}::timestamptz, {c32}::int))",
+      s"select * from users where (c1, c2, c3) in ((trim('v1_1'), '$ts'::timestamptz, 31), (trim('v1_2'), '$ts'::timestamptz, 32))"
+    )
+
+    validate(
+      Query("select * from users")
+        .in4(("c1", "c2", "c3", "c4"), Seq(("v1_1", ts, 31, "v4_1"), ("v1_2", ts, 32, "v4_2"))),
+      "select * from users where (c1, c2, c3, c4) in " +
+        "((trim({c1}), {c2}::timestamptz, {c3}::int, trim({c4})), (trim({c12}), {c22}::timestamptz, {c32}::int, trim({c42})))",
+      "select * from users where (c1, c2, c3, c4) in " +
+        s"((trim('v1_1'), '$ts'::timestamptz, 31, trim('v4_1')), (trim('v1_2'), '$ts'::timestamptz, 32, trim('v4_2')))"
+    )
+
+    validate(
+      Query("select * from users")
+        .in5(("c1", "c2", "c3", "c4", "c5"), Seq(("v1_1", ts, 31, "v4_1", ts), ("v1_2", ts, 32, "v4_2", ts))),
+      "select * from users where (c1, c2, c3, c4, c5) in (" +
+        "(trim({c1}), {c2}::timestamptz, {c3}::int, trim({c4}), {c5}::timestamptz), " +
+        "(trim({c12}), {c22}::timestamptz, {c32}::int, trim({c42}), {c52}::timestamptz)" +
+        ")",
+      s"select * from users where (c1, c2, c3, c4, c5) in (" +
+        s"(trim('v1_1'), '$ts'::timestamptz, 31, trim('v4_1'), '$ts'::timestamptz), " +
+        s"(trim('v1_2'), '$ts'::timestamptz, 32, trim('v4_2'), '$ts'::timestamptz)" +
+        s")"
+    )
+
+    validate(
+      Query("select * from users")
+        .in6(
+          ("c1", "c2", "c3", "c4", "c5", "c6"),
+          Seq(("v1_1", ts, 31, "v4_1", ts, 61), ("v1_2", ts, 32, "v4_2", ts, 62))
+        ),
+      "select * from users where (c1, c2, c3, c4, c5, c6) in (" +
+        "(trim({c1}), {c2}::timestamptz, {c3}::int, trim({c4}), {c5}::timestamptz, {c6}::int), " +
+        "(trim({c12}), {c22}::timestamptz, {c32}::int, trim({c42}), {c52}::timestamptz, {c62}::int))",
+      s"select * from users where (c1, c2, c3, c4, c5, c6) in (" +
+        s"(trim('v1_1'), '$ts'::timestamptz, 31, trim('v4_1'), '$ts'::timestamptz, 61), " +
+        s"(trim('v1_2'), '$ts'::timestamptz, 32, trim('v4_2'), '$ts'::timestamptz, 62)" +
+        s")"
+    )
+  }
+
   it("not in multiple") {
     validate(
       Query("select * from users").optionalNotIn("email", None),
@@ -395,10 +466,34 @@ class QuerySpec extends AnyFunSpec with Matchers {
         Seq("id", "org"),
         Seq(Seq("id1", "org1"), Seq("id2", "org2")),
         columnFunctions = Seq(Seq(Query.Function.Lower), Seq(Query.Function.Upper)),
-        valueFunctions = Seq(Seq(Query.Function.Lower, Query.Function.Trim), Seq(Query.Function.Upper))
+        valueFunctions =
+          Seq(Seq(Query.Function.Lower, Query.Function.Trim), Seq(Query.Function.Upper, Query.Function.Lower))
       ),
-      "select * from users where (lower(id), upper(org)) in ((lower(trim({id})), upper({org})), (lower(trim({id2})), upper({org2})))",
-      "select * from users where (lower(id), upper(org)) in ((lower(trim('id1')), upper('org1')), (lower(trim('id2')), upper('org2')))"
+      "select * from users where (lower(id), upper(org)) in " +
+        "((lower(trim({id})), upper(lower(trim({org})))), (lower(trim({id2})), upper(lower(trim({org2})))))",
+      "select * from users where (lower(id), upper(org)) in " +
+        "((lower(trim('id1')), upper(lower(trim('org1')))), (lower(trim('id2')), upper(lower(trim('org2')))))"
+    )
+  }
+
+  it("inN with functions") {
+    val ts = DateTime.now
+    validate(
+      Query("select * from users").in3(
+        ("id", "org", "created_at"),
+        Seq(("id1", "org1", ts), ("id2", "org2", ts)),
+        columnFunctions = (Seq(Query.Function.Lower), Seq(Query.Function.Upper), Seq.empty),
+        valueFunctions =
+          (Seq(Query.Function.Lower, Query.Function.Trim), Seq(Query.Function.Upper, Query.Function.Lower), Seq.empty)
+      ),
+      "select * from users where (lower(id), upper(org), created_at) in (" +
+        "(lower(trim({id})), upper(lower(trim({org}))), {created_at}::timestamptz), " +
+        "(lower(trim({id2})), upper(lower(trim({org2}))), {created_at2}::timestamptz)" +
+        ")",
+      "select * from users where (lower(id), upper(org), created_at) in (" +
+        s"(lower(trim('id1')), upper(lower(trim('org1'))), '$ts'::timestamptz), " +
+        s"(lower(trim('id2')), upper(lower(trim('org2'))), '$ts'::timestamptz)" +
+        ")"
     )
   }
 

--- a/src/test/scala/io/flow/postgresql/QuerySpec.scala
+++ b/src/test/scala/io/flow/postgresql/QuerySpec.scala
@@ -330,8 +330,7 @@ class QuerySpec extends AnyFunSpec with Matchers {
     )
 
     a[AssertionError] should be thrownBy {
-      Query("select * from users")
-        .inMulti(Seq("org", "users.email"), Seq(Seq("org1", "jean@flow.io"), Seq("org2")))
+      Query("select * from users").inMulti(Seq("org", "users.email"), Seq(Seq("org1", "jean@flow.io"), Seq("org2")))
     }
 
   }


### PR DESCRIPTION
Resolves [FDN-2249]

Use case: be able to generate queries on multiple columns such as:

```sql
select * from orders where (org, number) in (("o1", "n1"), ("o2", "n2"))
```

This change introduces:
 - inMulti
 - optionalInMulti
 - notInMulti
 - optionalNotInMulti

Usage:

```scala
Query("select * from orders").inMulti(Seq("org", "number"), Seq(Seq("o1", "n1"), Seq("o2", "n2")))
```

It can easily be leveraged in our decorator from our generated daos:

```scala
val orgOrders: Seq[Seq[String, String]] = ???
dao.findAll(limit = Some(orgOrders.size))(_.inMulti(Seq("org", "number"), orgNumbers))
```

___

Note this deploy requires DD as it introduces a new type and updated pattern matching.

[FDN-2249]: https://flowio.atlassian.net/browse/FDN-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ