### PR TITLE
Add journal diff functions to display details of diff in journaled tables

### DIFF
--- a/schema/journal-diff.sql
+++ b/schema/journal-diff.sql
@@ -1,0 +1,410 @@
+CREATE SCHEMA IF NOT EXISTS journal;
+
+-- DETAILS
+CREATE OR REPLACE FUNCTION journal.diff_details(
+  p_table_name TEXT,
+  p_ids ANYARRAY,
+  p_columns_to_compare TEXT[] DEFAULT NULL
+) RETURNS TABLE (id TEXT, diff TEXT) AS $$
+DECLARE
+  schema_name TEXT;
+  table_name_var TEXT;
+  column_names TEXT[];
+  from_column_names TEXT;
+  diff_columns TEXT;
+  query TEXT;
+BEGIN
+  -- Extract schema and table name
+  IF strpos(p_table_name, '.') > 0 THEN
+      schema_name := split_part(p_table_name, '.', 1);
+      table_name_var := split_part(p_table_name, '.', 2);
+  ELSE
+      schema_name := 'public';
+      table_name_var := p_table_name;
+  END IF;
+
+  -- Check that the table exists and contains both journal_id and journal_timestamp columns
+  IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns c
+      WHERE c.table_schema = schema_name
+      AND c.table_name = table_name_var
+      AND c.column_name IN ('journal_id', 'journal_timestamp')
+      GROUP BY c.table_schema, c.table_name
+      HAVING COUNT(DISTINCT c.column_name) = 2
+  ) THEN
+      RAISE EXCEPTION 'Table %I.%I does not exist or does not contain both journal_id and journal_timestamp columns', schema_name, table_name_var;
+  END IF;
+
+  -- Compute the list of columns to compare, keeping only the columns that are passed in if specified
+  SELECT array_agg(c.column_name::TEXT)
+  INTO column_names
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name NOT IN ('id', 'journal_id', 'journal_timestamp', 'journal_operation', '_updated_at', 'updated_at', 'version', '_version', 'hash_code', '_hash_code')
+  AND (p_columns_to_compare IS NULL OR c.column_name = ANY(p_columns_to_compare));
+
+  -- Generate the alias list for the hydrated CTE
+  SELECT string_agg(
+    format(
+      CASE
+        WHEN c.data_type IN ('json', 'jsonb') THEN 'o.%I::TEXT AS from_%I, j.%I::TEXT'
+        ELSE 'o.%I AS from_%I, j.%I'
+      END,
+      c.column_name, c.column_name, c.column_name
+    ), ', '
+  )
+  INTO from_column_names
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name = ANY(column_names);
+
+  -- Generate the diff logic for JSONB construction with specific formatting for journal fields
+  SELECT string_agg(
+    format(
+      'jsonb_build_object(''%I'', CASE WHEN from_%I IS DISTINCT FROM %I THEN COALESCE(from_%I::TEXT, ''<null>'') || '' -> '' || COALESCE(%I::TEXT, ''<null>'') ELSE NULL END)',
+      c.column_name, c.column_name, c.column_name, c.column_name, c.column_name
+    ), ' || '
+  )
+  INTO diff_columns
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name = ANY(column_names);
+
+  -- Construct the dynamic SQL query
+  query := format('
+    WITH ids AS (
+      SELECT DISTINCT id
+      FROM %I.%I
+      WHERE id = ANY(%L)
+    ), journals AS (
+      SELECT
+        id, journal_id, journal_timestamp, journal_operation,
+        %s,
+        lag(journal_id) OVER (PARTITION BY id ORDER BY journal_id ASC) AS from_journal_id
+      FROM %I.%I
+      WHERE id IN (SELECT id FROM ids)
+    ), hydrated AS (
+      SELECT
+        j.id AS id,
+        o.journal_id as from_journal_id,
+        j.journal_id,
+        o.journal_timestamp as from_journal_timestamp,
+        j.journal_timestamp,
+        o.journal_operation as from_journal_operation,
+        j.journal_operation,
+        %s
+      FROM journals j
+      JOIN journals o ON j.from_journal_id = o.journal_id
+    ), diffs AS (
+      SELECT
+        id,
+        journal_id,
+        jsonb_strip_nulls(
+          jsonb_build_object(
+            ''journal_timestamp'', CASE WHEN from_journal_timestamp IS DISTINCT FROM journal_timestamp THEN COALESCE(from_journal_timestamp::TEXT, ''<null>'') || '' -> '' || COALESCE(journal_timestamp::TEXT, ''<null>'') END,
+            ''journal_operation'', CASE WHEN from_journal_operation IS DISTINCT FROM journal_operation THEN COALESCE(from_journal_operation::TEXT, ''<null>'') || '' -> '' || COALESCE(journal_operation::TEXT, ''<null>'') END
+          ) || %s
+        ) AS diff
+      FROM hydrated
+      WHERE %s ORDER BY 1, 2 DESC
+    )
+    SELECT
+      id::TEXT,
+      jsonb_pretty(jsonb_agg(diff)) AS diff
+    FROM diffs
+    GROUP BY id
+    ORDER BY max(journal_id)
+  ',
+  schema_name, table_name_var,
+  p_ids,
+  array_to_string(column_names, ', '), schema_name, table_name_var,
+  from_column_names,
+  diff_columns,
+  (SELECT string_agg(
+    format(
+      'from_%I IS DISTINCT FROM %I',
+      column_name, column_name
+    ), ' OR '
+  ) FROM unnest(column_names) AS c(column_name))
+  );
+
+  -- Execute the dynamic SQL query
+  RETURN QUERY EXECUTE query;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION journal.diff_details(
+  p_table_name TEXT,
+  p_id TEXT,
+  p_columns_to_compare TEXT[] DEFAULT NULL
+) RETURNS TABLE (id TEXT, diff TEXT) AS $$
+-- call the array function
+BEGIN
+  RETURN QUERY
+  SELECT * FROM journal.diff_details(p_table_name, ARRAY[p_id], p_columns_to_compare);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION journal.diff_details(
+  p_table_name TEXT,
+  p_id BIGINT,
+  p_columns_to_compare TEXT[] DEFAULT NULL
+) RETURNS TABLE (id TEXT, diff TEXT) AS $$
+-- call the array function
+BEGIN
+  RETURN QUERY
+  SELECT * FROM journal.diff_details(p_table_name, ARRAY[p_id], p_columns_to_compare);
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- SUMMARY
+CREATE OR REPLACE FUNCTION journal.diff_summary(
+  p_table_name TEXT,
+  p_ids ANYARRAY
+) RETURNS TABLE (
+    distinct_ids bigint,
+    distinct_ids_with_history bigint,
+    distinct_journal_ids bigint,
+    distinct_journal_ids_with_previous bigint,
+    diff_counts TEXT
+) AS $$
+DECLARE
+  schema_name TEXT;
+  table_name_var TEXT;
+  column_names TEXT;
+  from_column_aliases TEXT;
+  count_statements TEXT;
+  jsonb_concat TEXT;
+  query TEXT;
+BEGIN
+  -- Extract schema and table name
+  IF strpos(p_table_name, '.') > 0 THEN
+      schema_name := split_part(p_table_name, '.', 1);
+      table_name_var := split_part(p_table_name, '.', 2);
+  ELSE
+      schema_name := 'public';
+      table_name_var := p_table_name;
+  END IF;
+
+ -- Check that the table exists and contains both journal_id and journal_timestamp columns
+  IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns c
+      WHERE c.table_schema = schema_name
+      AND c.table_name = table_name_var
+      AND c.column_name IN ('journal_id', 'journal_timestamp')
+      GROUP BY c.table_schema, c.table_name
+      HAVING COUNT(DISTINCT c.column_name) = 2
+  ) THEN
+      RAISE EXCEPTION 'Table %I.%I does not exist or does not contain both journal_id and journal_timestamp columns', schema_name, table_name_var;
+  END IF;
+
+  -- Compute the list of columns to compare, excluding specific columns
+  SELECT string_agg(c.column_name::TEXT, ', ')
+  INTO column_names
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name NOT IN ('id', 'journal_id', 'journal_timestamp', 'journal_operation', '_updated_at', 'updated_at', 'version', '_version', 'hash_code', '_hash_code');
+
+  -- Generate the alias list for the hydrated CTE
+  SELECT string_agg(
+    format(
+      CASE
+        WHEN c.data_type IN ('json', 'jsonb') THEN 'o.%I::TEXT AS from_%I, j.%I::TEXT'
+        ELSE 'o.%I AS from_%I, j.%I'
+      END,
+      c.column_name, c.column_name, c.column_name
+    ), ', '
+  )
+  INTO from_column_aliases
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name NOT IN ('id', 'journal_id', 'journal_timestamp', 'journal_operation', '_updated_at', 'updated_at', 'version', '_version', 'hash_code', '_hash_code');
+
+  -- Generate the count statements for differences dynamically, creating multiple jsonb_build_object calls concatenated with ||
+  SELECT string_agg(
+    format(
+      'jsonb_build_object(''%I'', NULLIF(count(*) filter (where from_journal_id is not null and %I IS DISTINCT FROM from_%I), 0))',
+      c.column_name, c.column_name, c.column_name
+    ), ' || '
+  )
+  INTO jsonb_concat
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name NOT IN ('id', 'journal_id', 'journal_timestamp', 'journal_operation', '_updated_at', 'updated_at', 'version', '_version', 'hash_code', '_hash_code');
+
+  -- Construct the dynamic SQL query
+  query := format('
+    WITH ids AS (
+      SELECT DISTINCT id
+      FROM %I.%I
+      %s
+    ), journals AS (
+      SELECT
+        id, journal_id, journal_timestamp, journal_operation,
+        %s,
+        lag(journal_id) OVER (PARTITION BY id ORDER BY journal_id ASC) AS from_journal_id
+      FROM %I.%I
+      WHERE id IN (SELECT id FROM ids)
+    ), hydrated AS (
+      SELECT
+        j.id,
+        o.journal_id as from_journal_id,
+        j.journal_id,
+        o.journal_timestamp as from_journal_timestamp,
+        j.journal_timestamp,
+        o.journal_operation as from_journal_operation,
+        j.journal_operation,
+        %s
+      FROM journals j
+      LEFT JOIN journals o ON j.from_journal_id = o.journal_id
+    )
+    SELECT
+      count(distinct id) as distinct_ids,
+      count(distinct id) filter (where from_journal_id is not null) as distinct_ids_with_history,
+      count(journal_id) as distinct_journal_ids,
+      count(journal_id) filter (where from_journal_id is not null) as distinct_journal_ids_with_previous,
+      jsonb_pretty(jsonb_strip_nulls(%s)) as diff_counts
+    FROM hydrated
+  ',
+  schema_name, table_name_var,
+  CASE WHEN p_ids IS NOT NULL THEN format('WHERE id = ANY(%L)', p_ids) ELSE '' END,
+  column_names, schema_name, table_name_var,
+  from_column_aliases,
+  jsonb_concat
+  );
+
+  -- Execute the dynamic SQL query
+  RETURN QUERY EXECUTE query;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION journal.diff_summary(
+  p_table_name TEXT
+) RETURNS TABLE (
+    distinct_ids bigint,
+    distinct_ids_with_history bigint,
+    distinct_journal_ids bigint,
+    distinct_journal_ids_with_previous bigint,
+    diff_counts TEXT
+) AS $$
+DECLARE
+  schema_name TEXT;
+  table_name_var TEXT;
+  column_names TEXT;
+  from_column_aliases TEXT;
+  count_statements TEXT;
+  jsonb_concat TEXT;
+  query TEXT;
+BEGIN
+  -- Extract schema and table name
+  IF strpos(p_table_name, '.') > 0 THEN
+      schema_name := split_part(p_table_name, '.', 1);
+      table_name_var := split_part(p_table_name, '.', 2);
+  ELSE
+      schema_name := 'public';
+      table_name_var := p_table_name;
+  END IF;
+
+ -- Check that the table exists and contains both journal_id and journal_timestamp columns
+  IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns c
+      WHERE c.table_schema = schema_name
+      AND c.table_name = table_name_var
+      AND c.column_name IN ('journal_id', 'journal_timestamp')
+      GROUP BY c.table_schema, c.table_name
+      HAVING COUNT(DISTINCT c.column_name) = 2
+  ) THEN
+      RAISE EXCEPTION 'Table %I.%I does not exist or does not contain both journal_id and journal_timestamp columns', schema_name, table_name_var;
+  END IF;
+
+  -- Compute the list of columns to compare, excluding specific columns
+  SELECT string_agg(c.column_name::TEXT, ', ')
+  INTO column_names
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name NOT IN ('id', 'journal_id', 'journal_timestamp', 'journal_operation', '_updated_at', 'updated_at', 'version', '_version', 'hash_code', '_hash_code');
+
+  -- Generate the alias list for the hydrated CTE
+  SELECT string_agg(
+    format(
+      CASE
+        WHEN c.data_type IN ('json', 'jsonb') THEN 'o.%I::TEXT AS from_%I, j.%I::TEXT'
+        ELSE 'o.%I AS from_%I, j.%I'
+      END,
+      c.column_name, c.column_name, c.column_name
+    ), ', '
+  )
+  INTO from_column_aliases
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name NOT IN ('id', 'journal_id', 'journal_timestamp', 'journal_operation', '_updated_at', 'updated_at', 'version', '_version', 'hash_code', '_hash_code');
+
+  -- Generate the count statements for differences dynamically, creating multiple jsonb_build_object calls concatenated with ||
+  SELECT string_agg(
+    format(
+      'jsonb_build_object(''%I'', NULLIF(count(*) filter (where from_journal_id is not null and %I IS DISTINCT FROM from_%I), 0))',
+      c.column_name, c.column_name, c.column_name
+    ), ' || '
+  )
+  INTO jsonb_concat
+  FROM information_schema.columns c
+  WHERE c.table_schema = schema_name
+  AND c.table_name = table_name_var
+  AND c.column_name NOT IN ('id', 'journal_id', 'journal_timestamp', 'journal_operation', '_updated_at', 'updated_at', 'version', '_version', 'hash_code', '_hash_code');
+
+  -- Construct the dynamic SQL query
+  query := format('
+    WITH ids AS (
+      SELECT DISTINCT id
+      FROM %I.%I
+    ), journals AS (
+      SELECT
+        id, journal_id, journal_timestamp, journal_operation,
+        %s,
+        lag(journal_id) OVER (PARTITION BY id ORDER BY journal_id ASC) AS from_journal_id
+      FROM %I.%I
+      WHERE id IN (SELECT id FROM ids)
+    ), hydrated AS (
+      SELECT
+        j.id,
+        o.journal_id as from_journal_id,
+        j.journal_id,
+        o.journal_timestamp as from_journal_timestamp,
+        j.journal_timestamp,
+        o.journal_operation as from_journal_operation,
+        j.journal_operation,
+        %s
+      FROM journals j
+      LEFT JOIN journals o ON j.from_journal_id = o.journal_id
+    )
+    SELECT
+      count(distinct id) as distinct_ids,
+      count(distinct id) filter (where from_journal_id is not null) as distinct_ids_with_history,
+      count(journal_id) as distinct_journal_ids,
+      count(journal_id) filter (where from_journal_id is not null) as distinct_journal_ids_with_previous,
+      jsonb_pretty(jsonb_strip_nulls(%s)) as diff_counts
+    FROM hydrated
+  ',
+  schema_name, table_name_var,
+  column_names, schema_name, table_name_var,
+  from_column_aliases,
+  jsonb_concat
+  );
+
+  -- Execute the dynamic SQL query
+  RETURN QUERY EXECUTE query;
+END;
+$$ LANGUAGE plpgsql;
+


### PR DESCRIPTION
Resolves [PAY-3887]

---

# Database Journal Diff Viewer

# Detailed diff

```sql
journal.diff_details(p_table_name TEXT, p_ids ANYARRAY, p_columns_to_compare TEXT[] DEFAULT NULL)
journal.diff_details(p_table_name TEXT, p_id TEXT, p_columns_to_compare TEXT[] DEFAULT NULL)
journal.diff_details(p_table_name TEXT, p_id BIGINT, p_columns_to_compare TEXT[] DEFAULT NULL)
```

```sql
RETURNS TABLE(id text, diff text)
```

**Description:**
This function generates a detailed diff report for the specified table and IDs. It compares the specified columns (or all columns if none are specified) between different versions of the rows identified by the given IDs.

**Parameters:**

- `p_table_name`: The name of the table to generate the diff report for. It can include the schema name (e.g., `journal.my_table`).
- `p_ids`: An array of IDs for which the diff report should be generated.
- `p_columns_to_compare`: An optional array of column names to compare. If not specified, all columns are compared.

**Variations:**

- `p_id` as `TEXT` / `BIGINT` instead of an array of

**Returns:**

- TABLE (id TEXT, diff TEXT): A table containing the ID and a pretty printed JSONB diff report displaying the diff between each journal entry.

**Example Usage:**

Specific id, all columns

```sql
select * from journal.diff_details('journal.my_variants', 716734875);
+-----------+-----------------------------------------------------------------------------------------------+
| id        | diff                                                                                          |
|-----------+-----------------------------------------------------------------------------------------------|
| 123123123 | [                                                                                             |
|           |     {                                                                                         |
|           |         "price": "21.69 -> 30.99",                                                            |
|           |         "compare_at_price": "30.99 -> <null>",                                                |
|           |         "journal_timestamp": "2024-08-23 18:29:32.801948+00 -> 2024-08-26 07:08:13.690525+00" |
|           |     },                                                                                        |
|           |     {                                                                                         |
|           |         "price": "23.24 -> 21.69",                                                            |
|           |         "journal_timestamp": "2024-08-23 18:28:38.242816+00 -> 2024-08-23 18:29:32.801948+00" |
|           |     }                                                                                         |
|           | ]                                                                                             |
+-----------+-----------------------------------------------------------------------------------------------+
```

Multiple IDs, specific columns

```sql
select * from journal.diff_details(
  p_table_name := 'journal.my_variants', 
  p_ids := ARRAY(select id from journal.my_variants limit 3), 
  p_columns_to_compare := ARRAY['price']
);
+-----------+-----------------------------------------------------------------------------------------------+
| id        | diff                                                                                          |
|-----------+-----------------------------------------------------------------------------------------------|
| 221950490 | [                                                                                             |
|           |     {                                                                                         |
|           |         "price": "39.99 -> 29.99",                                                            |
|           |         "journal_timestamp": "2024-08-23 12:55:07.990779+00 -> 2024-08-23 22:45:11.91059+00"  |
|           |     }                                                                                         |
|           | ]                                                                                             |
| 366567255 | [                                                                                             |
|           |     {                                                                                         |
|           |         "price": "57 -> 60",                                                                  |
|           |         "journal_timestamp": "2024-08-23 19:52:03.622481+00 -> 2024-08-25 13:04:49.072197+00" |
|           |     }                                                                                         |
|           | ]                                                                                             |
| 366921739 | [                                                                                             |
|           |     {                                                                                         |
|           |         "price": "53 -> 56",                                                                  |
|           |         "journal_timestamp": "2024-08-23 19:52:03.622481+00 -> 2024-08-25 13:04:49.072197+00" |
|           |     }                                                                                         |
|           | ]                                                                                             |
+-----------+-----------------------------------------------------------------------------------------------+
```

## Summarized Diff

```sql
journal.diff_summary(p_table_name TEXT)
journal.diff_summary(p_table_name TEXT, p_ids ANYARRAY)
```

```sql
RETURNS TABLE (
    distinct_ids bigint,
    distinct_ids_with_history bigint,
    distinct_journal_ids bigint,
    distinct_journal_ids_with_previous bigint,
    diff_counts TEXT
)
```

**Description**

This function computes a summary of differences in journal entries for a specified table, optionally filtered by a list of IDs. 

**Parameters**

- `p_table_name`: The name of the table to analyze. It can include the schema name (e.g., `public.table_name`)
- `p_ids` (optional): An optional array of IDs to filter the analysis.

**Returns**

- `distinct_ids`: The count of distinct IDs in the table.
- `distinct_ids_with_history`: The count of distinct IDs that have history (i.e. have previous journal entries)
- `distinct_journal_ids`: The count of distinct journal IDs in the table.
- `distinct_journal_ids_with_previous`: The count of distinct journal IDs that have previous entries.
- `diff_counts`: A pretty printed JSONB object representing the counts of differences for each column.

**Examples**

```sql
select * from journal.diff_summary(
  'journal.my_variants', 
  ARRAY(select id from journal.my_variants where organization_id = 'my_org')
);
-[ RECORD 1 ]-------------------------
distinct_ids                       | 58373
distinct_ids_with_history          | 58077
distinct_journal_ids               | 203342
distinct_journal_ids_with_previous | 144969
diff_counts                        | {
    "sku": 10,
    "price": 143379,
    "title": 10,
    "barcode": 29,
    "option1": 10,
    "option2": 10,
    "image_id": 46,
    "compare_at_price": 138892,
    "inventory_quantity": 5603
}
```

The whole table - no specific ids

```sql
select * from journal.diff_summary('journal.my_authorizations')
-[ RECORD 1 ]-------------------------
distinct_ids                       | 16029
distinct_ids_with_history          | 15362
distinct_journal_ids               | 46456
distinct_journal_ids_with_previous | 30427
diff_counts                        | {
    "processor": 9382,
    "order_number": 14157,
    "authorized_at": 6285,
    "result_action": 2708,
    "result_status": 21417
}
```

[PAY-3887]: https://flowio.atlassian.net/browse/PAY-3887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ