### PR TITLE
COR-2398: Upgrade libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val root = project
     libraryDependencies ++= Seq(
       "org.playframework.anorm" %% "anorm" % "2.8.1",
       "io.flow" %% "lib-test-utils-play28" % "0.2.43" % Test,
-      "org.postgresql" % "postgresql" % "42.7.4" % Test
+      "org.postgresql" % "postgresql" % "42.7.5" % Test
     ),
     resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
     resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,9 +7,9 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.60")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")


### PR DESCRIPTION
- io.flow
  - sbt-flow-linter (0.0.59 => 0.0.60)
- org.postgresql
  - postgresql (42.7.4 => 42.7.5)
- org.scalameta
  - sbt-scalafmt (2.5.2 => 2.5.4)
- org.scoverage
  - sbt-scoverage (2.2.2 => 2.3.0)